### PR TITLE
增加Swiftype站内搜索

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ mathjax:
 
 
 # Schemes
-#scheme: Mist
+scheme: Mist
 
 
 # Automatically scroll page to section which is under <!-- more --> mark.

--- a/layout/_partials/header.swig
+++ b/layout/_partials/header.swig
@@ -11,6 +11,22 @@
 
 {% if theme.menu %}
   <ul id="menu" class="menu">
+    {% if config.swiftype_key %}
+    <!--增加swiftype搜索功能-->
+    <form class="menu-item menu-item-{{ itemName }}">
+      <input type="text" id="st-search-input" class="st-search-input" style="width:80px;"  />
+    </form>
+    {% set swiftype_key = config.swiftype_key %}
+    <script type="text/javascript">
+    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+    })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
+
+    _st('install','{{swiftype_key}}');
+    </script>
+    <!--增加swiftype搜索功能end-->
+    {% endif %}
     {% for name, path in theme.menu %}
       {% set itemName = name.toLowerCase() %}
       <li class="menu-item menu-item-{{ itemName }}">


### PR DESCRIPTION
## 在menu上增加Swiftype站内搜索框
感谢作者的next主题，比较粗暴的直接在menu上增加了一个站内搜索框，更多的只是提个想法，希望能在下个版本中加入呢***第一次提交pull request好激动~***  
[在线预览](http://lizhuolun.com) | http://lizhuolun.com
### 使用说明
在站点的配置文件中增加
```
swiftype_key: yourswiftypekey
```
* 在官网后台控制面板中选择install，可看到自己的swiftype_key
![](http://7xiewb.com1.z0.glb.clouddn.com/image%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202015-04-05%20%E4%B8%8A%E5%8D%8810.26.10.png)
* 在这里默认使用了Swiftype的overplay样式，感觉和主题蛮搭的,也需要在Swiftype的官网后台设置一下，将样式改为overplay。
![](http://7xiewb.com1.z0.glb.clouddn.com/image%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202015-04-05%20%E4%B8%8A%E5%8D%8810.20.57.png)


**勾选overplay样式后保存即可，无需添加代码**
> Swiftype比什么百度站内搜索和google站内搜索好看多了，没有那么强的割裂感。