### PR TITLE
修复Swiftype搜索

### DIFF
--- a/layout/_partials/header.swig
+++ b/layout/_partials/header.swig
@@ -13,8 +13,8 @@
   <ul id="menu" class="menu">
      {% if config.swiftype_key %}
     <!--增加swiftype搜索功能-->
-    <form class="menu-item menu-item-{{ itemName }}">
-      <input type="text" id="st-search-input" class="st-search-input st-default-search-input" style="width:80px;float:left;"  />
+    <form class="menu-item menu-item-search">
+      <input type="text" id="st-search-input" class="st-search-input st-default-search-input" />
     </form>
     {% set swiftype_key = config.swiftype_key %}
     <script type="text/javascript">

--- a/layout/_partials/header.swig
+++ b/layout/_partials/header.swig
@@ -14,16 +14,16 @@
      {% if config.swiftype_key %}
     <!--增加swiftype搜索功能-->
     <form class="menu-item menu-item-{{ itemName }}">
-      <input type="text" id="st-search-input" class="st-search-input" style="width:80px;"  />
+      <input type="text" id="st-search-input" class="st-search-input st-default-search-input" style="width:80px;float:left;"  />
     </form>
     {% set swiftype_key = config.swiftype_key %}
     <script type="text/javascript">
-    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
-    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
-    })(window,document,'script','//s.swiftypecdn.com/install/v1/st.js','_st');
+      (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+      (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+      e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+      })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
 
-    _st('install','{{swiftype_key}}');
+      _st('install','{{swiftype_key}}','2.0.0');
     </script>
     <!--增加swiftype搜索功能end-->
     {% elseif config.tinysou_Key %}

--- a/source/css/_section/header.styl
+++ b/source/css/_section/header.styl
@@ -78,8 +78,8 @@
 
 //searchbar
 input.menu-search-input {
-  background-repeat: no-repeat;  
-  background-position: 5px center; 
+  background-repeat: no-repeat;
+  background-position: 5px center;
   width:70px;
   height:20px;
   padding:3px 9px 3px 23px;
@@ -95,7 +95,10 @@ input.menu-search-input {
 .menu .menu-item-search
   .st-search-input
     width 80px
-    float left
+    .theme-next &
+      float left
+    .theme-next-mist &
+      float none
   @media screen and (max-width: 767px)
     margin-bottom 15px
     display block

--- a/source/css/_section/header.styl
+++ b/source/css/_section/header.styl
@@ -60,6 +60,9 @@
 .menu .menu-item {
   display: inline-block;
   margin-left: 20px;
+  @media screen and (max-width: 767px) {
+    margin-top: 10px;
+  }
 
   &:first-child { margin-left: 0; }
 
@@ -95,8 +98,7 @@ input.menu-search-input {
 .menu .menu-item-search
   .st-search-input
     width 80px
-    .theme-next &
-      float left
+    float left
     .theme-next-mist &
       float none
   @media screen and (max-width: 767px)

--- a/source/css/_section/header.styl
+++ b/source/css/_section/header.styl
@@ -91,3 +91,14 @@ input.menu-search-input {
   background-image: url(/images/searchicon.png);
   background-size: 15px 15px;
 }
+
+.menu .menu-item-search
+  .st-search-input
+    width 80px
+    float left
+  @media screen and (max-width: 767px)
+    margin-bottom 15px
+    display block
+    .st-search-input
+      width auto
+      float none


### PR DESCRIPTION
这个PR修复了以下问题：
* 官网的代码已经更新到v2版本了，原来的代码已经失效了
* 官网提供的搜索框的class样式为`st-default-search-inupt`，而不是原来的`st-search-input`
* 默认的搜索栏位置有点偏下，加了`float:left`后效果稍微好一些(Mist上的效果不变)，如下图：
![effect](https://cloud.githubusercontent.com/assets/551329/7393187/f8f44d72-eebe-11e4-8b61-232bf5413e1d.png)
* 调整了搜索框在移动设备上的样式，移动设备上搜索框会变大，其他菜单项会换行，如下图：
![effect-mobile](https://cloud.githubusercontent.com/assets/551329/7394528/c089fa4c-eec6-11e4-84f2-4699c4747f88.png)

另外，WIKI里swiftype的配置也已经过期了，官网中设置时最重要的是三四两步。

* 搜索框设置和搜索结果样式设置

![step3-step4](https://cloud.githubusercontent.com/assets/551329/7393194/020fa8fc-eebf-11e4-9274-1fb7253a3961.png)

* 搜索框设置中直接选择“我已经有搜索框了”，而不是“我需要一个搜索框”，因为代码中已经包含搜索框

![search-field](https://cloud.githubusercontent.com/assets/551329/7393201/0a6d3f0a-eebf-11e4-9e93-3620e56d55d6.png)

* 搜索结果样式设置中对应原来的Overlay的设置
![overlay](https://cloud.githubusercontent.com/assets/551329/7393203/10a2388a-eebf-11e4-976d-8f25de02d16a.png)
