### PR TITLE
Fixed incorrect path in header

### DIFF
--- a/layout/_partials/header.swig
+++ b/layout/_partials/header.swig
@@ -51,7 +51,7 @@
     {% for name, path in theme.menu %}
       {% set itemName = name.toLowerCase() %}
       <li class="menu-item menu-item-{{ itemName }}">
-        <a href="{{ url_for(path) }}">
+        <a href="{{ (config.root + path) }}">
           <i class="menu-item-icon icon-{{ itemName }}"></i> <br />
           {{ __('menu.' + itemName) }}
         </a>


### PR DESCRIPTION
The paths in header.swig do not work when someone hosts his blog
in a subdirectory (e.g. domain.com/blog). By adding the config.root
(domain.com/blog) to the path (such as /category or /tags) this was fixed.