### PR TITLE
Extended english documentation (README.en.md)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -45,23 +45,36 @@ git pull
 
 ### English/Simplified Chinese language support.
 
-> Default language is English.
-> Set `language` field as following in site `_config.yml` to change to Chinese.
+Default language is English.
+
+```yml
+language: default
+```
+Set `language` field as following in site `_config.yml` to change to Chinese.
 
 ```yml
 language: zh-Hans
 ```
 
-### DuoShuo comment support.
+### Comment support.
 
-> Add `duoshuo` field to site `_config.yml`. For instance
+NexT has native support for `DuoShuo` and `Disqus` comment systems.
+
+Add the following snippets to your `_config.yml`:
 
 ```yml
 duoshuo:
   enable: true
-  shortname: duoshuo-shortname
+  shortname: your-duoshuo-shortname
 ```
 
+OR
+
+```yml
+disqus:
+   enable: true
+   shortname: your-disqus-shortname
+```
 
 ### Tags page.
 
@@ -83,6 +96,19 @@ duoshuo:
           home: /
           archives: /archives
           tags: /tags
+
+### Social Media
+
+NexT can automatically add links to your Social Media accounts:
+
+```yml
+social:
+  GitHub: your-github-url
+  Twitter: your-twitter-url
+  Weibo: your-weibo-url
+  DouBan: your-douban-url
+  ZhiHu: your-zhihu-url
+``` 
 
 ### Feed link.
 
@@ -120,6 +146,10 @@ menu:
 
 # Favicon
 favicon: /favicon.ico
+
+# Avatar (put the image into next/source/images/)
+# can be any image format supported by web browsers (JPEG,PNG,GIF,SVG,..)
+avatar: /default_avatar.png
 
 # Code highlight theme
 # available: normal | night | night eighties | night blue | night bright


### PR DESCRIPTION
Added documentation of default language, Duoshuo and Disqus comments,
integration with Social Media as well as how to use an avatar.

I tried translating bits and pieces of the chinese readme as well as testing it myself.

In the README.md I did not find any info on how to set an avatar, so you might want to add it there, too.