### PR TITLE
Update mathjax.swig

### DIFF
--- a/layout/_scripts/mathjax.swig
+++ b/layout/_scripts/mathjax.swig
@@ -1,4 +1,4 @@
-{% if theme.mathjax %}
+{% if page.mathjax %}
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     tex2jax: {


### PR DESCRIPTION
把调用mathjax的开关改下，某些页面不需要用到数学公式就不用调用了，这样加载速度更快。
需要调用时，在页面标签中加入mathjax标签即可：
```
title: test
date: 2015-05-27 13:07:16
tags: 测试
mathjax: true
---
```