### PR TITLE
修复需要配置两次discus_shortname的问题

### DIFF
--- a/layout/_scripts/comments/disqus.swig
+++ b/layout/_scripts/comments/disqus.swig
@@ -1,9 +1,9 @@
 {% if not (theme.duoshuo and theme.duoshuo.shortname) and not theme.duoshuo_shortname %}
 
-  {% if theme.disqus_shortname %}
+  {% if config.disqus_shortname %}
 
     <script type="text/javascript">
-      var disqus_shortname = '{{theme.disqus_shortname}}';
+      var disqus_shortname = '{{config.disqus_shortname}}';
       var disqus_identifier = '{{ page.path }}';
       var disqus_title = '{{ page.title }}';
       var disqus_url = '{{ page.permalink }}';


### PR DESCRIPTION
使用theme.disqus_shortname会从theme的config读取参数，而post.swig是读取config.disqus_shortname的。此处应该统一，否则需要在两个_config都配置才可以启动discus