### PR TITLE
Explicitly initiate sidebar with display: none.

### DIFF
--- a/source/css/_common/_section/sidebar.styl
+++ b/source/css/_common/_section/sidebar.styl
@@ -38,6 +38,7 @@
 .sidebar {
   width: 0;
   position: fixed;
+  display: none;
   right: 0;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
In the end I actually thing that the missing `display: none` _is_ coming from the NeXT theme. This patch actually does fix the issue for me.

Fixes #239