### PR TITLE
保证图片的title可以在fancy box中显示

### DIFF
--- a/source/js/fancy-box.js
+++ b/source/js/fancy-box.js
@@ -7,7 +7,9 @@ $(document).ready(function() {
       $imageWrapLink = $image.wrap('<a href="' + this.getAttribute('src') + '"></a>').parent('a');
     }
     $imageWrapLink.addClass('fancybox');
-    $imageWrapLink.attr("title",this.title); //make sure img title tag will show correctly in fancybox
+    if(this.title){
+      $imageWrapLink.attr("title",this.title); //make sure img title tag will show correctly in fancybox
+    }
   });
 });
 $('.fancybox').fancybox({

--- a/source/js/fancy-box.js
+++ b/source/js/fancy-box.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
       $imageWrapLink = $image.wrap('<a href="' + this.getAttribute('src') + '"></a>').parent('a');
     }
     $imageWrapLink.addClass('fancybox');
+    $imageWrapLink.attr("title",this.title); //make sure img title tag will show correctly in fancybox
   });
 });
 $('.fancybox').fancybox({


### PR DESCRIPTION
fancybox生成链接
![default](https://cloud.githubusercontent.com/assets/2445380/8633760/8f3da4a0-280c-11e5-8a8c-592b47c198a8.png)
标签需要携带图片的title，这样才能保证在页面fancy box中显示title内容