### PR TITLE
修复在source/css/_custom/custom.styl下添加变量无效的bug

### DIFF
--- a/source/css/main.styl
+++ b/source/css/main.styl
@@ -20,6 +20,10 @@ for $mixin in $mixins
   @import "_mixins/" + $mixin;
 
 
+// Custom Layer
+// --------------------------------------------------
+@import "_custom/custom";
+
 
 // Common Layer
 // --------------------------------------------------
@@ -44,9 +48,6 @@ for $mixin in $mixins
 // Vendors
 @import "_common/_vendor/highlight/highlight";
 
-// Custom Layer
-// --------------------------------------------------
-@import "_custom/custom";
 
 // Sections
 @import "_common/_section/layout";
@@ -76,7 +77,6 @@ for $mixin in $mixins
 @import "_common/_page/archive";
 @import "_common/_page/post-detail";
 @import "_common/_page/categories";
-
 
 
 // Schemes Layer

--- a/source/css/main.styl
+++ b/source/css/main.styl
@@ -44,6 +44,9 @@ for $mixin in $mixins
 // Vendors
 @import "_common/_vendor/highlight/highlight";
 
+// Custom Layer
+// --------------------------------------------------
+@import "_custom/custom";
 
 // Sections
 @import "_common/_section/layout";
@@ -79,9 +82,3 @@ for $mixin in $mixins
 // Schemes Layer
 // --------------------------------------------------
 @import "_schemes/" + $scheme;
-
-
-
-// Custom Layer
-// --------------------------------------------------
-@import "_custom/custom";


### PR DESCRIPTION
## 问题描述
根据官方文档描述，在`source/css/_custom/custom.styl`下添加`$content-desktop`变量可以自定义内容宽度，以及`$font-family-headings`与`$font-family-base`自定义字体，实际设定该变量无效。

## 问题原因
实际设定参数后无法完成效果。原因在于`main.styl`中将`"_custom/custom"`在最后`@import`，
之前的`"_common/_section/layout"`中已经将`$content-desktop`变量赋值完毕。

## 解决办法
将`Custom Layer`放置在`Common Layer`之前

## 小提醒
官方文档中如下描述
![](http://7xkgg5.com1.z0.glb.clouddn.com/Others/next-theme-pull-request.png)
纠正一处笔误：
`source/css/_custom/variables.styl`应该更正为`source/css/_custom/custom.styl`。