### PR TITLE
添加博主在ua显示页面里的昵称自定义功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ duoshuo_info:
   ua_enable: true
   admin_enable: false
   user_id: 0
+  #admin_nickname: ROOT
 
 ## DO NOT EDIT THE FOLLOWING SETTINGS
 ## UNLESS YOU KNOW WHAT YOU ARE DOING

--- a/layout/_scripts/comments/duoshuo.swig
+++ b/layout/_scripts/comments/duoshuo.swig
@@ -19,8 +19,10 @@
   </script>
     {% if theme.duoshuo_info.ua_enable %}
      {% if theme.duoshuo_info.admin_enable %}
+     {% if theme.duoshuo_info.admin_nickname %}
   	  <script type="text/javascript">
   		var duoshuo_user_ID = {{theme.duoshuo_info.user_id}}
+      var duoshuo_admin_nickname="{{theme.duoshuo_info.admin_nickname}}"
   	  </script>
      {% endif %}
   	<script src="{{ url_for(theme.js) }}/ua-parser.min.js"></script>

--- a/source/js/hook-duoshuo.js
+++ b/source/js/hook-duoshuo.js
@@ -17,7 +17,11 @@ function hook_duoshuo_templates() {
 		var is_admin;
 		if (typeof duoshuo_user_ID !== 'undefined') {
 			if (e.post.author.user_id && (e.post.author.user_id == duoshuo_user_ID)) {
-				is_admin = '<span class="this_ua admin">博主</span>'
+				if(duoshuo_admin_nickname){
+				is_admin = '<span class="this_ua admin">'+duoshuo_admin_nickname+'</span>'
+				}else{
+					is_admin = '<span class="this_ua admin">博主</span>'
+				}
 			} else {
 				is_admin = '';
 			}


### PR DESCRIPTION
完善这个[PR](https://github.com/iissnan/hexo-theme-next/pull/286#issuecomment-132862802)#286 ，一个小功能，自定义博主在UA显示页面里的昵称。

---
使用方法:
------
如果喜欢默认的`博主`字段，则不需要对配置做任何更改，按照[这里](https://github.com/iissnan/hexo-theme-next/pull/286#issuecomment-121923123)的方式配置即可。

如果想将其更改为其余字段，譬如`ROOT`、`Admin`等，需要在主题配置的`duoshuo_info`字段下，将` #admin_nickname: ROOT`的注释取消，然后将`ROOT`改成你想要的任何名字即可

---
预览效果：
-----
**默认：**
![image](https://cloud.githubusercontent.com/assets/8258592/9381294/91b2d9aa-4768-11e5-885c-651ca4e02973.png)

**自定义后:**
![image](https://cloud.githubusercontent.com/assets/8258592/9381299/9fdbba42-4768-11e5-970d-d87bcefb37df.png)