### PR TITLE
change mathjax cdn to staticfile.org cdn

### DIFF
--- a/layout/_scripts/mathjax.swig
+++ b/layout/_scripts/mathjax.swig
@@ -18,5 +18,7 @@
   });
 </script>
 
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="http://cdn.staticfile.org/mathjax/2.4.0/MathJax.js"></script>
+<script type="text/javascript" src="http://cdn.staticfile.org/mathjax/2.4.0/config/TeX-AMS-MML_HTMLorMML.js"></script>
+
 {% endif %}


### PR DESCRIPTION
mathjax的js加载速度比较慢，一个js文件的加载都超过1s。改为七牛静态文件cdn，mathjax js加载速度快些。

但是：最新版的MathJax已经是2.5版本。七牛cdn上最新的2.4版本。