### PR TITLE
如果文章front-matter里有keywords属性，则使用页面的keywords，而不是直接使用tags

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -36,7 +36,9 @@
     <meta name="description" content="{{ config.description }}" />
 {% endif %}
 
-{% if page.tags and page.tags.length %}
+{% if page.keywords %}
+  <meta name="keywords" content="{{ page.keywords }}" />
+{% elif page.tags and page.tags.length %}
   <meta name="keywords" content="{% for tag in page.tags %}{{ tag.name }},{% endfor %}" />
 {% elif theme.keywords %}
   <meta name="keywords" content="{{ theme.keywords }}" />


### PR DESCRIPTION
RT,这样对于有自定义keywords需求的使用者来说更灵活