### PR TITLE
Enable Fancybox image gallery

### DIFF
--- a/source/js/fancy-box.js
+++ b/source/js/fancy-box.js
@@ -8,6 +8,7 @@ $(document).ready(function() {
       $imageWrapLink = $image.wrap('<a href="' + this.getAttribute('src') + '"></a>').parent('a');
     }
     $imageWrapLink.addClass('fancybox');
+    $imageWrapLink.attr('rel', 'group');
     if ($image.attr("alt")) {
       $imageWrapLink.append('<div class="pic-title"><span>' + $image.attr("alt") + '</span></div>');
       $imageWrapLink.attr("title",$image.attr("alt")); //make sure img title tag will show correctly in fancybox


### PR DESCRIPTION
Please view demo [here](http://fancyapps.com/fancybox/#examples). In gallery mode, the box can be navigated via mouse clicking on the image or pressing arrow key.