### PR TITLE
优化图片标题样式; 更改是否显示图片标题的判断条件. - dev branch

### DIFF
--- a/source/css/_custom/custom.styl
+++ b/source/css/_custom/custom.styl
@@ -1,6 +1,6 @@
 // Custom styles.
 
-.post-body p img {
+.post-body img {
     margin: 0 auto;
     cursor: pointer;
     cursor: zoom-out;
@@ -8,22 +8,21 @@
     display: block!important;
 }
 
-.post-body p .pic-title {
+.post-body .pic-title {
 	margin: 0 auto;
     text-align: center;
 }
 
 .post-body p .pic-title span {
-    min-width: 20%;
-    min-height: 22px;
+    min-width: 10%;
+    min-height: 20px;
     display: inline-block;
-    padding: 10px;
+    padding: 5px;
     margin: 0 auto;
     border-bottom: 1px solid #d9d9d9;
-    font-size: 18px;
+    font-size: 14px;
     color: #999999;
-    font-style: italic;
-    line-height: 1.7;
+    font-weight: bold;
 }
 
 .posts-expand .post-body .fancybox img {

--- a/source/js/fancy-box.js
+++ b/source/js/fancy-box.js
@@ -10,11 +10,11 @@ $(document).ready(function() {
 
     $imageWrapLink.addClass('fancybox');
 
-    if ($image.attr("alt")) {
-      $imageWrapLink.append('<div class="pic-title"><span>' + $image.attr("alt") + '</span></div>');
+    if ($image.attr("title")) {
+      $imageWrapLink.append('<div class="pic-title"><span>' + $image.attr("title") + '</span></div>');
 
       //make sure img title tag will show correctly in fancybox
-      $imageWrapLink.attr("title", $image.attr("alt"));
+      $imageWrapLink.attr("title", $image.attr("title"));
     }
   });
 });


### PR DESCRIPTION
图片标题减小了字号; 标题字体样式由斜体更改为粗体; 为class="full-image"的图片添加标题样式.
更改为只有设置了title的图片才显示标题, 不设置则不显示.
图片标题样式可见：http://blog.mrx.one