### PR TITLE
优化图片标题样式; 更改是否显示图片标题的判断条件.

### DIFF
--- a/source/css/_common/_component/posts.styl
+++ b/source/css/_common/_component/posts.styl
@@ -6,18 +6,20 @@
   cursor: -webkit-zoom-in;
 }
 
-.post-body p .pic-title {
+.post-body .pic-title {
   margin: 0 auto;
   text-align: center;
 }
 
 .post-body p .pic-title span {
   display: inline-block;
+  min-width: 10%;
+  min-height: 20px;
   margin: 10px auto 0;
   padding: 2px 0;
   border-bottom: 1px solid $grey-dark;
   font-size: $font-size-base;
   color: $grey-dark;
-  font-style: italic;
+  font-weight: bold;
   line-height: 1;
 }

--- a/source/css/_common/_component/posts.styl
+++ b/source/css/_common/_component/posts.styl
@@ -11,7 +11,7 @@
   text-align: center;
 }
 
-.post-body p .pic-title span {
+.post-body .pic-title span {
   display: inline-block;
   min-width: 10%;
   min-height: 20px;

--- a/source/js/fancy-box.js
+++ b/source/js/fancy-box.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $('.content img').not('.group-picture img').each(function () {
 
     var $image = $(this);
-    var imageTitle = $image.attr('alt');
+    var imageTitle = $image.attr('title');
     var $imageWrapLink = $image.parent('a');
 
     if ($imageWrapLink.size() < 1) {


### PR DESCRIPTION
之前那次PR被覆盖掉了，重新提交下。
更新内容：
图片标题减小了字号; 标题字体样式由斜体更改为粗体; 为class="full-image"的图片添加标题样式.
更改为只有设置了title的图片才显示标题, 不设置则不显示.
图片标题样式可见：http://blog.mrx.one