### PR TITLE
使用中科大字体库替换360字体库

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -28,7 +28,7 @@
 
 {% if theme.use_font_lato %}
   {% if config.language === 'zh-Hans' %}
-    <link href='//fonts.useso.com/css?family=Lato:300,400,700,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+    <link href='//fonts.lug.ustc.edu.cn/css?family=Lato:300,400,700,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
   {% else %}
     <link href='//fonts.googleapis.com/css?family=Lato:300,400,700,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
   {% endif %}


### PR DESCRIPTION
由于360字体库不支持HTTPS，网站开启HTTPS后无法加载字体，所以更换为中科大的字体库，支持HTTPS。