### PR TITLE
 使用id获取多说script对象

### DIFF
--- a/layout/_scripts/comments/duoshuo.swig
+++ b/layout/_scripts/comments/duoshuo.swig
@@ -11,6 +11,7 @@
     (function() {
       var ds = document.createElement('script');
       ds.type = 'text/javascript';ds.async = true;
+      ds.id = 'duoshuo-script';
       ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
       ds.charset = 'UTF-8';
       (document.getElementsByTagName('head')[0]

--- a/source/js/hook-duoshuo.js
+++ b/source/js/hook-duoshuo.js
@@ -1,7 +1,7 @@
 if (typeof DUOSHUO !== 'undefined') {
 	hook_duoshuo_templates();
 } else {
-	$('[src="http://static.duoshuo.com/embed.js"]')[0].onload = hook_duoshuo_templates;
+	$('#duoshuo-script')[0].onload = hook_duoshuo_templates;
 }
 var is_hook_duoshuo = false;
 


### PR DESCRIPTION
修复当用户使用自己托管的多说脚本时，因找不到`http://static.duoshuo.com/embed.js`而报`Uncaught TypeError: Cannot set property 'onload' of undefined`的BUG。

错误截图：
![1.png](https://ooo.0o0.ooo/2015/10/19/56250cb4af18a.png "1.png")
![2.png](https://ooo.0o0.ooo/2015/10/19/56250cb73af2c.png "2.png")
