### PR TITLE
Fix the issue of image not align center

### DIFF
--- a/source/css/_common/_component/posts-expand.styl
+++ b/source/css/_common/_component/posts-expand.styl
@@ -155,4 +155,4 @@
 
 .post-more-link { margin-top: 50px; }
 
-.posts-expand .fancybox img { margin: 0 auto; }
+.posts-expand .post-body .fancybox img { margin: 0 auto; }


### PR DESCRIPTION
I found that the next theme do not align the image center.

And based on what I can found on css, when `.fancy-box` is applied to the image, usually we want that image to align center:
```css
.posts-expand .fancybox img { margin: 0 auto; }
```

But the fact is that, there is another rule which also meet the `img` element, which overwrite this rule:
```css
.posts-expand .post-body img { margin: 0 }
```

The second on is before the fancybox, so the img cannot align center.

So let's fix it.
