### PR TITLE
add missing loc string and fix site state item wrap issue under en

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -22,6 +22,7 @@ post:
   read_more: Read more
   untitled: Untitled
   toc_empty: This post does not have a Table Of Contents
+  visitors: visitors
 
 page:
   totally: Totally

--- a/source/css/_common/components/sidebar/site-state.styl
+++ b/source/css/_common/components/sidebar/site-state.styl
@@ -1,6 +1,7 @@
 .site-state {
   overflow: hidden;
   line-height: 1.4;
+  white-space: nowrap;
 }
 
 .site-state-item {


### PR DESCRIPTION
Issues：

1. missing the "visitors" under english language for `visitor counter` item, right now it will use chinese string under english language config, so add it.
2. the site state items, such as `tags`, `categories` and `posts`, when under english language, because the `categories` word is long, so the div with `site-state-item` is wrapped. So let's fix it.