### PR TITLE
Variable white space above/below post separator

### DIFF
--- a/source/css/_common/_component/posts-expand.styl
+++ b/source/css/_common/_component/posts-expand.styl
@@ -145,7 +145,7 @@
 .posts-expand {
   .post-eof {
     display: block;
-    margin: 160px auto 120px;
+    margin: $post-eof-margin-top auto $post-eof-margin-bottom;
     width: 8%;
     height: 1px;
     background: $grey-light;

--- a/source/css/_variables/default.styl
+++ b/source/css/_variables/default.styl
@@ -1,0 +1,4 @@
+//  .post-expand .post-eof
+//  In the default scheme, margin above and below the post separator
+$post-eof-margin-top    = 80px  //  or 160px for more white space
+$post-eof-margin-bottom = 60px  //  or 120px for less white space


### PR DESCRIPTION
The default scheme has considerable white space above and below the post separator on index pages. This change makes the white space variable by creating two new variables in `/source/css/_variables/default.styl` and using them in `/source/css/_common/_component/posts-expand.styl` to allow theme users to adjust white space easily.