### PR TITLE
修复多说评论不显示admin_nickname名称问题

### DIFF
--- a/source/js/src/hook-duoshuo.js
+++ b/source/js/src/hook-duoshuo.js
@@ -15,7 +15,7 @@ function hookTemplate() {
     var userId = e.post.author.user_id;
     var admin = '';
 
-    if (userId && (userId === CONFIG.duoshuo.userId)) {
+    if (userId && (userId == CONFIG.duoshuo.userId)) {
       admin = '<span class="duoshuo-ua-admin">' + CONFIG.duoshuo.author + '</span>';
     }
 


### PR DESCRIPTION
userId是string，CONFIG.duoshuo.userId是number，所以不用严格比较