### PR TITLE
多说评论ua信息显示颜色修改

### DIFF
--- a/source/css/_common/components/third-party/duoshuo.styl
+++ b/source/css/_common/components/third-party/duoshuo.styl
@@ -164,7 +164,7 @@
 
   #ds-reset .duoshuo-ua-platform,
   #ds-reset .duoshuo-ua-browser {
-    color: #ccc;
+    color: #666;
 
     .fa {
       display: inline-block;


### PR DESCRIPTION
不知道是否作者有意如此，我感觉原先的#ccc的颜色太白了，现在改成了#666
原效果
![default](https://cloud.githubusercontent.com/assets/3283023/11898263/83a166a2-a5d1-11e5-9e19-e2e0cbcb84b9.png)

现在效果
![default](https://cloud.githubusercontent.com/assets/3283023/11898266/879e144e-a5d1-11e5-9644-1ded668aff2f.png)
