### PR TITLE
Style hexo-renderer-markdown-it's automatic headline ID's

### DIFF
--- a/source/css/_common/_component/posts-expand.styl
+++ b/source/css/_common/_component/posts-expand.styl
@@ -82,6 +82,22 @@
 
   h2, h3, h4, h5, h6 {
     padding-top: 10px;
+
+    .header-anchor{
+      float: right;
+      margin-left: 10px;
+      color: $grey-light;
+      border-bottom-style: none;
+      visibility: hidden;
+
+      &:hover{
+        color: inherit;
+      }
+    }
+
+    &:hover .header-anchor{
+      visibility: visible;
+    }
   }
 
   img {


### PR DESCRIPTION
See https://github.com/celsomiranda/hexo-renderer-markdown-it/wiki/Advanced-Configuration#automatic-headline-ids

hexo-renderer-markdown can add permalinks to headings. However, they are
prepended to the heading and styled like a regular link, which doesn't look
that good. This pull request moves it to the right, hides it when not hovering the
heading, and tones it down until the actual anchor is hovered.

You can preview what it looks like now over here: http://vincenttunru.com/Error-Error-while-waiting-for-Protractor-to-sync-with-the-page/#how-to-solve-it (hover over the heading)