### PR TITLE
Fix issue #616

### DIFF
--- a/source/css/_common/scaffolding/helpers.styl
+++ b/source/css/_common/scaffolding/helpers.styl
@@ -57,21 +57,6 @@
   }
 }
 
-.video-container {
-  position: relative;
-  padding-top: 60%;
-  height: 0;
-  overflow: hidden;
-
-  iframe, object, embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-}
-
 .affix.affix.affix { position: fixed; }
 
 .translation {


### PR DESCRIPTION
已经在utils.js中使用embeddedVideoTransformer方法指定了内嵌视频的样式，删除helpers.styl中重复的样式，修复因套用两层position:relative导致的视频显示异常。