### PR TITLE
Fix issue #609

### DIFF
--- a/source/css/_common/components/pages/archive.styl
+++ b/source/css/_common/components/pages/archive.styl
@@ -16,6 +16,7 @@
 
   .posts-collapse {
     position: relative;
+    z-index: $zindex-1;
 
     &::after {
       top: 20px;


### PR DESCRIPTION
Pisces 设置了一个白色背景，导致时间轴被覆盖。给其父元素增加一个层级。