### PR TITLE
Fix invisible list style #559

### DIFF
--- a/source/css/_schemes/Muse/index.styl
+++ b/source/css/_schemes/Muse/index.styl
@@ -1,3 +1,5 @@
+ul li { list-style: disc; }
+
 @import "_logo.styl";
 @import "_menu.styl";
 @import "_search.styl";

--- a/source/css/_schemes/Pisces/index.styl
+++ b/source/css/_schemes/Pisces/index.styl
@@ -1,4 +1,5 @@
 body { background: #f5f7f9; }
+ul li { list-style: disc; }
 
 @import "_full-image";
 @import "_layout";


### PR DESCRIPTION
Related issue: https://github.com/iissnan/hexo-theme-next/issues/559

- I would consider `ul { list-style: none }` is for resetting.
- Default choice for list style is `disc`. If your design mean it to be `circle`, I can amend it. 