### PR TITLE
添加AddThis社交分享功能

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -175,6 +175,7 @@ mathjax:
 
 # Share
 #jiathis:
+#add_this_id:
 
 # Share
 #duoshuo_share: true

--- a/layout/_partials/share/add-this.swig
+++ b/layout/_partials/share/add-this.swig
@@ -1,0 +1,4 @@
+<!-- Go to www.addthis.com/dashboard to customize your tools -->
+<script type = "text/javascript"
+src = "//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-56a07c3ac699e3ca"
+async = "async" > </script>

--- a/layout/_partials/share/add-this.swig
+++ b/layout/_partials/share/add-this.swig
@@ -1,4 +1,2 @@
 <!-- Go to www.addthis.com/dashboard to customize your tools -->
-<script type = "text/javascript"
-src = "//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-56a07c3ac699e3ca"
-async = "async" > </script>
+<script type = "text/javascript" src = "//s7.addthis.com/js/300/addthis_widget.js#pubid={{ theme.add_this_id }}" async = "async" ></script>

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -16,6 +16,8 @@
     <div class="post-spread">
       {% if theme.jiathis %}
         {% include '_partials/share/jiathis.swig' %}
+      {% elseif theme.add_this_id %}
+        {% include '_partials/share/add-this.swig' %}
       {% elseif theme.duoshuo_shortname and theme.duoshuo_share %}
         {% include '_partials/share/duoshuo_share.swig' %}
       {% endif %}


### PR DESCRIPTION
**添加AddThis理由：**
1. 更为清爽的设计风格（个人认为好于JiaThis）
2. 除了Facebook、Twitter、Google+、Linkedin等海外常用的分享外，还包括微博在内的上百分享选择
3. Mobile Friendly
4. Freemium

**注册AddThis方法**
1. 在网站[AddThis](https://www.addthis.com/)上注册账号。可以使用Google/Facebook/Twitter账号进行第三方登陆。
2. 从下面菜单获得AddThis id：`More.. --> General --> ID`。具体ID获得方式可以[参考截图](http://i.imgur.com/HN2Dcwb.png)。
3. 在主题`_config.yml`中，把`#Share`下的
`#add_this_id`
取消注释，改为
`add_this_id: put_your_add_this_id_here`

**参考网站**
[我的博客](http://hackjustu.ninja/)加入了AddThis分享功能。点击进入任何一个post，把鼠标放到屏幕左侧即滑出分享按钮（按钮滑出的位置可以在AddThis网站调整）。当屏幕缩小到移动设备大小时，或者在手机上看时，按钮显示在屏幕下方。

我使用的主题版本是去年十月左右fork出去的，所以看起来有点不同。我用最新的主题测试过，没有问题：）

