### PR TITLE
Add wechat and alipay reward for post

### DIFF
--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -114,6 +114,7 @@
                <span class="leancloud-visitors-count"></span>
               </span>
           {% endif %}
+
         </div>
       </header>
     {% endif %}
@@ -175,6 +176,12 @@
       {% else %}
         {{ post.content }}
       {% endif  %}
+    </div>
+
+    <div>
+      {% if ! is_index %}
+        {% include 'reward.swig' %}
+      {% endif %}
     </div>
 
     <footer class="post-footer">

--- a/layout/_macro/reward.swig
+++ b/layout/_macro/reward.swig
@@ -1,0 +1,22 @@
+{% if theme.alipay || theme.wechatpay %}
+<div style="padding: 10px 0; margin: 20px auto; width: 90%; text-align: center">
+  <div>{{ theme.reward_comment }}</div>
+  <button id="rewardButton", disable="enable", onclick="var qr = document.getElementById('QR'); if (qr.style.display === 'none') {qr.style.display='block';} else {qr.style.display='none'}", style="cursor: pointer; border: 0; outline: 0; border-radius: 100%; padding: 0; margin: 0; letter-spacing: normal; text-transform: none; text-indent: 0px; text-shadow: none">
+    <span onmouseover="this.style.color='rgb(236,96,0)';this.style.background='rgb(204,204,204)'" onMouseOut="this.style.color='#fff';this.style.background='rgb(236,96,0)'" style="display: inline-block; width: 70px; height: 70px; border-radius: 100%; line-height: 81px; color: #fff; font: 400 35px/75px 'microsofty'; background: rgb(236,96,0)">赏</span>
+  </button>
+  <div id="QR" style="display: none;">
+    {% if theme.wechatpay %}
+      <div id="wechat" style="display: inline-block">
+        <img id="wechat_qr" src="{{ theme.wechatpay }}" alt="{{ theme.author }} WeChat Pay" style="width: 200px; max-width: 100%; display: inline-block"/>
+        <p>微信打赏</p>
+      </div>
+    {% endif %}
+    {% if theme.alipay %}
+      <div id="alipay" style="display: inline-block">
+        <img id="alipay_qr" src="{{ theme.alipay }}" alt="{{ theme.author }} Alipay" style="width: 200px; max-width: 100%; display: inline-block"/>
+        <p>支付宝打赏</p>
+      </div>
+    {% endif %}
+  </div>
+<div>
+{% endif %}


### PR DESCRIPTION
越来越多的平台（微信公众平台，新浪微博，简书，百度打赏等）支持打赏功能，付费阅读时代越来越近，特此增加了打赏功能，支持微信打赏和支付宝打赏。只需要_config.xml中填入微信和支付宝收款二维码即可开启该功能。
未点击效果
![unclick](https://cloud.githubusercontent.com/assets/3096874/13395408/7fc00b88-df29-11e5-9890-895357206ecf.png)

鼠标悬浮效果
![hover](https://cloud.githubusercontent.com/assets/3096874/13395407/7f3d9176-df29-11e5-84a3-e7da2c1fcad5.png)

点击之后效果
![click](https://cloud.githubusercontent.com/assets/3096874/13395406/7f3d6c8c-df29-11e5-9e3c-f5b22297e2b2.png)