### PR TITLE
Fix rss feed url

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -47,7 +47,7 @@
 
 
 {% if theme.rss === '' and config.feed and config.feed.path %}
-  {% set theme.rss = config.root + config.feed.path %}
+  {% set theme.rss = config.feed.path %}
 {% endif %}
 {% if theme.rss %}
   <link rel="alternate" href="{{ url_for(theme.rss) }}" title="{{ config.title }}" type="application/atom+xml" />


### PR DESCRIPTION
```
{% set theme.rss = config.root + config.feed.path %}
```

then

```
url_for(theme.rss)
```

results in doubling path prefix.