### PR TITLE
Fix overflow of table content when in mobile view

### DIFF
--- a/source/css/_common/scaffolding/tables.styl
+++ b/source/css/_common/scaffolding/tables.styl
@@ -5,6 +5,8 @@ table {
   border-spacing: 0;
   border: 1px solid $table-border-color;
   font-size: $table-font-size;
+  table-layout: fixed;
+  word-wrap: break-word;
 }
 table>tbody>tr {
   &:nth-of-type(odd) { background-color: $table-row-odd-bg-color; }


### PR DESCRIPTION
1. Force table size by fix the layout.
2. Force word break even there is no available breakpoints.