### PR TITLE
site-state center align in sidebar when theme is Pisces

### DIFF
--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -55,6 +55,9 @@
   }
 }
 
+.site-state {
+  text-align: center;
+}
 
 .feed-link {
   border-top: 1px dotted $grey-light;


### PR DESCRIPTION
当使用主题 Pisces，并且 site-state-item 不足三个、只有一个或两个 site-state-item 的时候，site-state 是左对齐的，很不好看没有平衡感，将 site-state 修改为居中对齐