### PR TITLE
fix a issue for fonts hosts replacement, original font.host cannot ge…

### DIFF
--- a/layout/_partials/head/external-fonts.swig
+++ b/layout/_partials/head/external-fonts.swig
@@ -44,7 +44,7 @@
 
   {% if font_families !== '' %}
     {% set font_families += '&subset=latin,latin-ext' %}
-    {% set font_host = font.host | default('//fonts.googleapis.com') %}
+    {% set font_host = font_config.host | default('//fonts.googleapis.com') %}
     <link href="{{ font_host }}/css?family={{ font_families }}" rel="stylesheet" type="text/css">
   {% endif %}
 


### PR DESCRIPTION
发现修改了配置文件中的fonts的host之后，检查元素还是用了google的字体库，不起作用，然后跟踪排查了一下，好像是这里写错了，我试着改了，生效。