### PR TITLE
Fix friendly links

### DIFF
--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -93,8 +93,8 @@
         {% endif %}
 
         {# Blogroll #}
-        <div class="links-of-blogroll motion-element">
-          {% if theme.links %}
+        {% if theme.links %}
+          <div class="links-of-blogroll motion-element">
             <div class="links-of-blogroll-title">{{ theme.links_title }}</div>
             <ul class="links-of-blogroll-list">
               {% for name, link in theme.links %}
@@ -103,8 +103,8 @@
                 </li>
               {% endfor %}
             </ul>
-          {% endif %}
-        </div>
+          </div>
+        {% endif %}
 
       </section>
 


### PR DESCRIPTION
修复当未设置友情连接时链接区域会显示的问题。
Before:
![20160411003](https://cloud.githubusercontent.com/assets/7333266/14429589/9c8be5de-0030-11e6-91ec-00a35c6259d4.png)
After:
![20160411004](https://cloud.githubusercontent.com/assets/7333266/14429606/a47fa528-0030-11e6-9223-cea3940de69c.png)

