### PR TITLE
add icon for friendly link title.

### DIFF
--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -95,7 +95,10 @@
         {# Blogroll #}
         {% if theme.links %}
           <div class="links-of-blogroll motion-element">
-            <div class="links-of-blogroll-title">{{ theme.links_title }}</div>
+            <div class="links-of-blogroll-title">
+              <i class="fa fa-{{ theme.links_icon || 'globe' }} fa-fw"></i>
+              {{ theme.links_title }}
+            </div>
             <ul class="links-of-blogroll-list">
               {% for name, link in theme.links %}
                 <li class="links-of-blogroll-item">


### PR DESCRIPTION
Add icon for friendly link title, see [友情链接](http://theme-next.iissnan.com/theme-settings.html#blogroll), add a new item `links_icon`

```
# title
links_title: Links
links_icon: heartbeat
links:
  MacTalk: http://macshuo.com/
  Title: http://example.com/
```

The result can be seen on http://consen.github.io and http://mayliar.github.io
