### PR TITLE
minor bug in JS code

### DIFF
--- a/source/js/src/post-details.js
+++ b/source/js/src/post-details.js
@@ -42,7 +42,7 @@ $(document).ready(function () {
 
     $(document)
       .on('affixed.bs.affix', function () {
-        updateTOCHeight(document.body.clientHeight - 100)
+        updateTOCHeight(document.body.clientHeight - 100);
       });
   }
 


### PR DESCRIPTION
Earlier today I ran the `gulp` command in my project and got this error regarding a missing semi-colon. As per gulp's suggestion, I then went into `source/js/post-detail.js` and saw that there was in fact a missing semi colon on line [48](https://github.com/iissnan/hexo-theme-next/blob/master/source/js/src/post-details.js#L45) so I took the proper steps (added the semi-color), and after that gulp ran to success. 

Below, you can see the minor change I made. 


Also, awesome theme man! I really enjoy using it... thank you 😄 