### PR TITLE
fix social_icons bug.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -130,9 +130,9 @@ social_icons:
   enable: true
   # Icon Mappings.
   # KeyMapsToSocalItemKey: NameOfTheIconFromFontAwesome
-  GitHub: github
-  Twitter: twitter
-  Weibo: weibo
+  github: github
+  twitter: twitter
+  weibo: weibo
 
 
 # Sidebar Avatar


### PR DESCRIPTION
according to `Font Awesome Icons`, 'social_icons' keys should be lower-case.