### PR TITLE
load mathjax only when mathjax is needed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -228,6 +228,7 @@ auto_excerpt:
 # MathJax Support
 mathjax:
   enable: false
+  per_page: false
   cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 

--- a/layout/_scripts/third-party/mathjax.swig
+++ b/layout/_scripts/third-party/mathjax.swig
@@ -1,21 +1,23 @@
 {% if theme.mathjax.enable %}
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-      tex2jax: {
-        inlineMath: [ ['$','$'], ["\\(","\\)"]  ],
-        processEscapes: true,
-        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
-      }
-    });
-  </script>
+  {% if not theme.mathjax.per_page or (page.total or page.mathjax) %}
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"]  ],
+          processEscapes: true,
+          skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        }
+      });
+    </script>
 
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Queue(function() {
-      var all = MathJax.Hub.getAllJax(), i;
-      for (i=0; i < all.length; i += 1) {
-        all[i].SourceElement().parentNode.className += ' has-jax';
-      }
-    });
-  </script>
-  <script type="text/javascript" src="{{ theme.mathjax.cdn }}"></script>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Queue(function() {
+        var all = MathJax.Hub.getAllJax(), i;
+        for (i=0; i < all.length; i += 1) {
+          all[i].SourceElement().parentNode.className += ' has-jax';
+        }
+      });
+    </script>
+    <script type="text/javascript" src="{{ theme.mathjax.cdn }}"></script>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
原始代码中若开启`mathjax`选项，则所有页面都会加载mathjax。如果100篇博文里只有10篇有公式，那么对于另外90篇博文来说，加载mathjax就太浪费了。此PR的目的是实现仅当需要时再加载mathjax。

改动只有两处：

1. 加了配置参数 `per_page`，默认值为`false`
2. 加了判断条件 `{% if not theme.mathjax.per_page or (page.total or page.mathjax)%}` （其他行只是修改了代码缩进）

最终的结果是：

1. 若`theme.mathjax.enable==false`，则所有页面都不加载mathjax
2. 若`theme.mathjax.enable==true`，且 `theme.mathjax.per_page==false`，则所有页面都加载mathjax。由于`theme.mathjax.per_page`默认值为`false`，所以增加这个参数不会造成兼容性问题，不介意所有页面都加载mathjax的只要不修改这个参数就可以了
3. 若`theme.mathjax.enable==true`，且 `theme.mathjax.per_page==true`，则意味着会按需加载mathjax。此时需要在每个有公式的博文的front-matter中加上`mathjax: true`。新增的条件语句的后半部分的作用是仅在index页以及`mathjax: true`的页面加载mathjax。

这里的一个小trick是，使用 `page.total`来判断当前页面是否是index。对于index页面，`page.total`是当前页面的总post数目，相当于true，对于post页面，`page.total`是未定义的，相当于false。
