### PR TITLE
support custom head

### DIFF
--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -93,3 +93,5 @@
     }
   };
 </script>
+
+{% include 'head/custom-head.swig' %}

--- a/layout/_partials/head/custom-head.swig
+++ b/layout/_partials/head/custom-head.swig
@@ -1,0 +1,3 @@
+{#
+Custom head.
+#}


### PR DESCRIPTION
用户可以自行在head中加入信息。这样做有两个好处：

1. 灵活性，比如百度统计之类的功能即便主题不支持也可以自己添加
2. 易于更新，避免了用户修改 `head.swig` 之后更新主题时出现冲突