### PR TITLE
double quote and use addslashes on disqus title

### DIFF
--- a/layout/_scripts/third-party/comments/disqus.swig
+++ b/layout/_scripts/third-party/comments/disqus.swig
@@ -5,7 +5,7 @@
     <script type="text/javascript">
       var disqus_shortname = '{{theme.disqus_shortname}}';
       var disqus_identifier = '{{ page.path }}';
-      var disqus_title = '{{ page.title }}';
+      var disqus_title = "{{ page.title|addslashes }}";
       var disqus_url = '{{ page.permalink }}';
 
       function run_disqus_script(disqus_script){


### PR DESCRIPTION
Previously if you had a single quote in your post title a javascript error would prevent the page from functioning correctly. With this functionality we will double quote the `post.title` in the inject javascript and use the builtin swig filter `addslashes` to escape characters that need to be escaped.