### PR TITLE
Support Facebook Comments Plugin.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -287,6 +287,13 @@ facebook_sdk:
   like_button:  #true
   webmaster:    #true
 
+# Facebook comments plugin
+# This plugin depends on Facebook SDK.
+# If facebook_sdk.enable is false, Facebook comments plugin is unavailable.
+facebook_comments_plugin:
+  enable: false
+  num_of_posts: 10
+
 
 # Show number of visitors to each article.
 # You can visit https://leancloud.cn get AppID and AppKey.

--- a/layout/_partials/comments.swig
+++ b/layout/_partials/comments.swig
@@ -4,6 +4,11 @@
       <div class="ds-thread" data-thread-key="{{ page.path }}"
            data-title="{{ page.title }}" data-url="{{ page.permalink }}">
       </div>
+    {% elseif theme.facebook_sdk.enable and theme.facebook_comments_plugin.enable %}
+      <div class="fb-comments"
+           data-href="{{ page.permalink }}"
+           data-numposts="{{ theme.facebook_comments_plugin.num_of_posts }}">
+      </div>
     {% elseif theme.disqus_shortname %}
       <div id="disqus_thread">
         <noscript>

--- a/layout/_scripts/third-party/analytics/facebook-sdk.swig
+++ b/layout/_scripts/third-party/analytics/facebook-sdk.swig
@@ -4,7 +4,7 @@
     FB.init({
       appId      : '{{ theme.facebook_sdk.app_id }}',
       xfbml      : true,
-      version    : 'v2.5'
+      version    : 'v2.6'
     });
   };
 


### PR DESCRIPTION
In this commit:
    1. Upgrade Facebook SDK from v2.5 to v2.6 (2016/04/12)
    2. Support Facebook Comments Plugin

You could find the demonstration via [this link](https://hydai.co/2016/05/22/helloworld/?fb_comment_id=1198213520198318_1198218393531164#fe8ed19e0dfb8a).

And the following is the screenshot from my demonstration page:
<img width="577" alt="2016-06-02 12 27 05" src="https://cloud.githubusercontent.com/assets/2776756/15717291/e5bf7856-2858-11e6-8798-afa187c7e66b.png">
