### PR TITLE
gallery posts 中的图片不应该被再次 fancybox 化

### DIFF
--- a/source/js/src/utils.js
+++ b/source/js/src/utils.js
@@ -5,7 +5,7 @@ NexT.utils = NexT.$u = {
    * Wrap images with fancybox support.
    */
   wrapImageWithFancyBox: function () {
-    $('.content img').not('.group-picture img').each(function () {
+    $('.content img').not('.group-picture img, .post-gallery img').each(function () {
 
       var $image = $(this);
       var imageTitle = $image.attr('title');


### PR DESCRIPTION
wrapImageWithFancyBox 这个功能除了要排除 .group-picture 中的 img 以外，还应该排除 .post-gallery 中的 img。因为 .post-gallery 中的 img 已经包围 fancybox，并且拥有相同的 rel 属性，如果再次应用的话，虽然不会再套一层链接，但 rel 属性会变成跟相册图片之外的图片一样的 "group"，这样 fancybox 中的下一张和上一张会浏览到相册以外的无关图片。现已修复，请 merge。