### PR TITLE
make value of lang attr responsive

### DIFF
--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -11,7 +11,7 @@
   <title>{% block title %}{% endblock %}</title>
 </head>
 
-<body itemscope itemtype="http://schema.org/WebPage" lang="{{ config.language }}">
+<body itemscope itemtype="http://schema.org/WebPage" lang="{{ page.lang || page.language || config.language }}">
 
   {% include '_scripts/third-party/analytics.swig' %}
 


### PR DESCRIPTION
在 front-matter 中指定 `lang: <lang_code>` 或 ` language: <lang_code>` 对于 hexo 来说是有作用的，hexo 会应用主题中相应的语言文件生成对应语言的页面，如果 front-matter 中没有特殊指定，则采用站点配置文件中所设定的语言，从而使特定页面的语言不同于整站语言。而 next 中，页面的 lang 属性被强制设定为站点配置文件中指定的语言，对于多语言博客来说，会产生页面实际语言与 lang 属性中描述的语言不一致的情况。虽然多语言博客需求可能不大，但代码改动也不大，建议 merge。