### PR TITLE
Update add-this.swig, fix a not-shown problem

### DIFF
--- a/layout/_partials/share/add-this.swig
+++ b/layout/_partials/share/add-this.swig
@@ -1,2 +1,4 @@
 <!-- Go to www.addthis.com/dashboard to customize your tools -->
-<script type = "text/javascript" src = "//s7.addthis.com/js/300/addthis_widget.js#pubid={{ theme.add_this_id }}" async = "async" ></script>
+<div class="addthis_inline_share_toolbox">
+  <script type = "text/javascript" src = "//s7.addthis.com/js/300/addthis_widget.js#pubid={{ theme.add_this_id }}" async = "async" ></script>
+</div>


### PR DESCRIPTION
The reason is due to lack the style of the button. Now it works.
Add the document need to update since the user need to visit AddThis, under the "Tools" menu, select the according style, just pick the "inline share buttons", that's ok.