### PR TITLE
corrected disqus example in readme

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -54,7 +54,6 @@ language: en
 # language: zh-hk
 # language: zh-tw
 # language: ru
-# language: ru
 # language: de
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -79,9 +79,7 @@ duoshuo:
 OR
 
 ```yml
-disqus:
-   enable: true
-   shortname: your-disqus-shortname
+disqus_shortname: your-disqus-shortname
 ```
 
 ### Tags page.
@@ -104,7 +102,7 @@ disqus:
           home: /
           archives: /archives
           tags: /tags
-          
+
 ### Categories page.
 
 > Add a categories page contains all categories in your site.
@@ -137,7 +135,7 @@ social:
   Weibo: your-weibo-url
   DouBan: your-douban-url
   ZhiHu: your-zhihu-url
-``` 
+```
 
 ### Feed link.
 


### PR DESCRIPTION
This PR updates the readme to use the same syntax as used in [`_config` example](https://github.com/iissnan/hexo-theme-next/blob/master/_config.yml#L247) for disqus integration.
