### PR TITLE
Fixes in CSS styles of code blocks.

### DIFF
--- a/source/css/_common/components/highlight/diff.styl
+++ b/source/css/_common/components/highlight/diff.styl
@@ -1,0 +1,8 @@
+$highlight_theme = hexo-config("highlight_theme")
+
+if $highlight_theme == "normal"
+  $highlight-deletion     = #fdd
+  $highlight-addition     = #dfd
+else
+  $highlight-deletion     = #008000
+  $highlight-addition     = #800000

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -8,7 +8,6 @@ $code-block {
   overflow: auto;
   margin: 20px 0;
   padding: 15px;
-  border-radius: $code-border-radius;
   font-size $code-font-size;
   color: $highlight-foreground;
   background: $highlight-background;
@@ -19,7 +18,7 @@ pre, code { font-family: $code-font-family; }
 
 code {
   padding: 2px 4px;
-  word-break: break-all;
+  word-wrap: break-all;
   color: $highlight-foreground;
   background: $highlight-background;
   border-radius: $code-border-radius;

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -1,6 +1,7 @@
 // https://github.com/chriskempson/tomorrow-theme
 
 @require "theme"
+@require "diff"
 
 // Placeholder: $code-block
 $code-block {
@@ -88,15 +89,9 @@ pre {
 }
 
 // For diff highlight
-pre .deletion {
-  background: #fdd;
-}
-pre .addition {
-  background: #dfd;
-}
-pre .meta {
-  color: $highlight-purple;
-}
+pre .deletion { background: $highlight-deletion; }
+pre .addition { background: $highlight-addition; }
+pre .meta     { color: $highlight-purple; }
   
 pre {
 

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -86,8 +86,19 @@ pre {
   td { border: none; }
 }
 
+// For diff highlight
+pre .deletion {
+  background: #fdd;
+}
+pre .addition {
+  background: #dfd;
+}
+pre .meta {
+  background: #ddf;
+}
+  
 pre {
-
+  .meta
   .comment { color: $highlight-comment; }
 
   .variable

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -19,8 +19,8 @@ pre, code { font-family: $code-font-family; }
 code {
   padding: 2px 4px;
   word-break: break-all;
-  color: $code-foreground;
-  background: $code-background;
+  color: $highlight-foreground;
+  background: $highlight-background;
   border-radius: $code-border-radius;
   font-size $code-font-size;
 }
@@ -95,11 +95,11 @@ pre .addition {
   background: #dfd;
 }
 pre .meta {
-  background: #ddf;
+  color: $highlight-purple;
 }
   
 pre {
-  .meta
+
   .comment { color: $highlight-comment; }
 
   .variable

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -7,6 +7,7 @@ $code-block {
   overflow: auto;
   margin: 20px 0;
   padding: 15px;
+  border-radius: $code-border-radius;
   font-size $code-font-size;
   color: $highlight-foreground;
   background: $highlight-background;

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -1,7 +1,7 @@
 .header {
   position: relative;
   margin: 0 auto;
-  width: 960px;
+  width: $main-desktop;
 
   +tablet() {
     width: auto;

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -143,8 +143,6 @@ $table-row-hover-bg-color       = $whitesmoke
 // --------------------------------------------------
 $code-font-family               = $font-family-monospace
 $code-font-size                 = 13px
-$code-background                = $gainsboro
-$code-foreground                = $black-light
 $code-border-radius             = 3px
 
 

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -145,7 +145,7 @@ $code-font-family               = $font-family-monospace
 $code-font-size                 = 13px
 $code-background                = $gainsboro
 $code-foreground                = $black-light
-$code-border-radius             = 4px
+$code-border-radius             = 3px
 
 
 


### PR DESCRIPTION
1. Add support diff highlight style (#1079).
2. Add border radius to code blocks.
3. Tomorrow theme on single code blocks.

[Demo](https://almostover.ru/2016-01/hexo-next-diff-highlight-test/).

---
## Tomorrow Normal
![image](https://cloud.githubusercontent.com/assets/16944225/18031901/5ca57e24-6cfc-11e6-9a9e-15427c54edff.png)
---
## Tomorrow Night
![image](https://cloud.githubusercontent.com/assets/16944225/18031904/77b879b4-6cfc-11e6-98ac-d96c4bd51550.png)
---
## Tomorrow Night blue
![image](https://cloud.githubusercontent.com/assets/16944225/18031906/8e931b26-6cfc-11e6-89ad-0f13c491a9a0.png)