### PR TITLE
improvement of localsearch

### DIFF
--- a/layout/_scripts/third-party/comments/duoshuo.swig
+++ b/layout/_scripts/third-party/comments/duoshuo.swig
@@ -12,7 +12,7 @@
       var ds = document.createElement('script');
       ds.type = 'text/javascript';ds.async = true;
       ds.id = 'duoshuo-script';
-      ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.js';
+      ds.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') + '//static.duoshuo.com/embed.unstable.js';
       ds.charset = 'UTF-8';
       (document.getElementsByTagName('head')[0]
       || document.getElementsByTagName('body')[0]).appendChild(ds);

--- a/layout/_scripts/third-party/localsearch.swig
+++ b/layout/_scripts/third-party/localsearch.swig
@@ -43,7 +43,7 @@
                 if (this.value.trim().length > 1) {
                 // perform local searching
                 datas.forEach(function(data) {
-                    var isMatch = true;
+                    var isMatch = false;
                     var content_index = [];
                     var data_title = data.title.trim().toLowerCase();
                     var data_content = data.content.trim().replace(/<[^>]+>/g,"").toLowerCase();
@@ -52,20 +52,17 @@
                     var index_content = -1;
                     var first_occur = -1;
                     // only match artiles with not empty titles and contents
-                    if(data_title != '' && data_content != '') {
+                    if(data_title != '') {
                         keywords.forEach(function(keyword, i) {
                             index_title = data_title.indexOf(keyword);
                             index_content = data_content.indexOf(keyword);
-                            if( index_title < 0 && index_content < 0 ){
-                                isMatch = false;
-                            } else {
-                                if (index_content < 0) {
-                                    index_content = 0;
-                                }
-                                if (i == 0) {
+                            if( index_title >= 0 || index_content >= 0 ){
+                                isMatch = true;
+								if (i == 0) {
                                     first_occur = index_content;
                                 }
-                            }
+                            } 
+							
                         });
                     }
                     // show search results

--- a/source/css/_common/components/third-party/localsearch.styl
+++ b/source/css/_common/components/third-party/localsearch.styl
@@ -17,11 +17,13 @@ a.search-result {
   text-overflow: ellipsis;
 }
 .search-keyword {
-  border-bottom: 1px dashed #4088b8;
+  border-bottom: 1px dashed #f00;
+  font-size: 14px;
   font-weight: bold;
+  color: #f00;
 }
 #local-search-result {
-  height: 90%;
+  height: 88%;
   overflow: auto;
 }
 .popup {
@@ -61,8 +63,12 @@ a.search-result {
 
 #local-search-input {
   margin-bottom: 10px;
-  width: 50%;
+  padding: 10px;
+  width: 97%;
+  font-size: 18px
 }
+
+.popup .fa-search{padding-top:8px;}
 
 .popup-btn-close {
   position: absolute;


### PR DESCRIPTION
1、美化localsearch弹窗显示
2、修复localsearch算法小bug
bug描述：
``isMatch``变量默认为``true`` (localsearch.swig 46行)，那么当 search.xml 中出现有标题但无内容的条目时，算法会绕过字符串匹配过程，这将导致该条目会永远显示在搜索结果中，不论是否匹配。
当 hexo-generator-search 插件``field: all``时生成的 categories 和 tags 页面内容为空，所以此时无论输入什么内容，搜索结果中都会显示这两个页面。
bug修复之前：
![修改之前](http://o9w8f1xrl.bkt.clouddn.com/issues/localsearch1.jpg)
bug修复之后：
![修改之后](http://o9w8f1xrl.bkt.clouddn.com/issues/localsearch2.jpg)

修改之后的 localsearch 效果演示[www.wuxubj.cn](http://www.wuxubj.cn)