### PR TITLE
Show overview widget by default at the side bar when user is reading an

### DIFF
--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -14,16 +14,16 @@
 
       {% if display_toc %}
         <ul class="sidebar-nav motion-element">
-          <li class="sidebar-nav-toc sidebar-nav-active" data-target="post-toc-wrap" >
-            {{ __('sidebar.toc') }}
-          </li>
-          <li class="sidebar-nav-overview" data-target="site-overview">
+          <li class="sidebar-nav-overview sidebar-nav-active" data-target="site-overview">
             {{ __('sidebar.overview') }}
+          </li>
+          <li class="sidebar-nav-toc" data-target="post-toc-wrap" >
+            {{ __('sidebar.toc') }}
           </li>
         </ul>
       {% endif %}
 
-      <section class="site-overview sidebar-panel {% if not display_toc %} sidebar-panel-active {% endif %}">
+      <section class="site-overview sidebar-panel  sidebar-panel-active ">
         <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
           <img class="site-author-image" itemprop="image"
                src="{{ url_for( theme.avatar | default(theme.images + '/avatar.gif') ) }}"
@@ -112,7 +112,7 @@
       </section>
 
       {% if display_toc %}
-        <section class="post-toc-wrap motion-element sidebar-panel sidebar-panel-active">
+        <section class="post-toc-wrap motion-element sidebar-panel ">
           <div class="post-toc">
             {% if page.toc_number === undefine %}
               {% set toc = toc(page.content, { "class": "nav", list_number: theme.toc.number }) %}


### PR DESCRIPTION
当站点使用**pisces scheme**，读者在阅读文章的时候，侧边栏默认显示的是**文章目录**。
然而很多时候，作者并没有使用header标签，那么文章目录就会是空的，这样不是十分美观(请观察[这篇文章](http://notes.iissnan.com/2015/upgrade-computer-components/)的侧边栏)。
这个PR就是将文章阅读界面侧边栏默认显示改为**站点概览**以此避免文章目录空白的尴尬。
