### PR TITLE
duoshuo  Head.swig template configuration is missing symbol problem

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -6,7 +6,7 @@ gulp.task 'lint', ->
   return gulp.src([
     './source/js/src/utils.js',
     './source/js/src/motion.js',
-    './source/js/src/hook-duoshuo.js'
+    './source/js/src/hook-duoshuo.js',
     './source/js/src/bootstrap.js',
     './source/js/src/post-details.js',
     './source/js/src/schemes/pisces.js'

--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -88,7 +88,7 @@
     fancybox: {{ theme.fancybox }},
     motion: {{ theme.use_motion }},
     duoshuo: {
-      userId: {{ theme.duoshuo_info.user_id | default() }},
+      userId: '{{ theme.duoshuo_info.user_id | default() }}',
       author: '{{ theme.duoshuo_info.admin_nickname | default(__('author'))}}'
     }
   };


### PR DESCRIPTION
今天博客突然变白屏看不到文章了，检查发现多说js错误导致后面的fancybox出错，文章元素被设为opacity:0导致的白屏。
多说的模板head.swig文件里
`duoshuo: {
      userId: {{ theme.duoshuo_info.user_id | default() }},
      author: '{{ theme.duoshuo_info.admin_nickname | default(__('author'))}}'
    }`
这里的userId没有加引号，一些情况下没有被正确当成字符串处理，浏览器会报对象未定义的错误，加上引号后就都不会出错了,
没有引号时浏览器会报错，报错图片
![](http://od6ri688q.bkt.clouddn.com/%E5%A4%9A%E8%AF%B4%E9%85%8D%E7%BD%AE%E7%96%91%E4%BC%BCbugQQ%E5%9B%BE%E7%89%8720160908233001.png)
您看下是不是存在这个问题