### PR TITLE
Add Hypercomments system.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -244,6 +244,9 @@ mathjax:
 # Disqus
 #disqus_shortname:
 
+# Hypercomments
+#hypercomments_id: 
+
 # Baidu Share
 # Available value:
 #    button | slide

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -94,6 +94,18 @@
                   <span class="post-comments-count disqus-comment-count" data-disqus-identifier="{{ post.path }}" itemprop="commentsCount"></span>
                 </a>
               </span>
+            {% elseif theme.hypercomments_id %}
+            <!--noindex-->
+              <span class="post-comments-count">
+                &nbsp;|&nbsp;
+                  <span class="post-meta-item-icon">
+                    <i class="fa fa-comment-o"></i>
+                    <a href="{{ url_for(post.path) }}#comments" itemprop="discussionUrl">
+                      <span class="post-comments-count hc-comment-count" data-xid="{{ post.path }}" itemprop="commentsCount"></span>
+                    </a>
+                  </span>
+              </span>
+              <!--/noindex-->
             {% endif %}
           {% endif %}
 

--- a/layout/_partials/comments.swig
+++ b/layout/_partials/comments.swig
@@ -11,6 +11,8 @@
           <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a>
         </noscript>
       </div>
+    {% elseif theme.hypercomments_id %}
+      <div id="hypercomments_widget"></div>
     {% endif %}
   </div>
 {% endif %}

--- a/layout/_scripts/third-party/comments.swig
+++ b/layout/_scripts/third-party/comments.swig
@@ -1,2 +1,3 @@
 {% include './comments/duoshuo.swig' %}
 {% include './comments/disqus.swig' %}
+{% include './comments/hypercomments.swig' %}

--- a/layout/_scripts/third-party/comments/hypercomments.swig
+++ b/layout/_scripts/third-party/comments/hypercomments.swig
@@ -1,0 +1,27 @@
+{% if not (theme.duoshuo and theme.duoshuo.shortname) and not theme.duoshuo_shortname and not theme.disqus_shortname %}
+
+	{% if theme.hypercomments_id %}
+
+		<script type="text/javascript">
+		_hcwp = window._hcwp || [];
+
+		_hcwp.push({widget:"Bloggerstream", widget_id: {{ theme.hypercomments_id }}, selector:".hc-comment-count", label: "{\%COUNT%\}" });
+
+		{% if page.comments %}
+		_hcwp.push({widget:"Stream", widget_id: {{ theme.hypercomments_id }}, xid: "{{ page.path }}"});
+		{% endif %}
+
+		(function() {
+		if("HC_LOAD_INIT" in window)return;
+		HC_LOAD_INIT = true;
+		var lang = (navigator.language || navigator.systemLanguage || navigator.userLanguage || "en").substr(0, 2).toLowerCase();
+		var hcc = document.createElement("script"); hcc.type = "text/javascript"; hcc.async = true;
+		hcc.src = ("https:" == document.location.protocol ? "https" : "http")+"://w.hypercomments.com/widget/hc/{{ theme.hypercomments_id }}/"+lang+"/widget.js";
+		var s = document.getElementsByTagName("script")[0];
+		s.parentNode.insertBefore(hcc, s.nextSibling);
+		})();
+		</script>
+
+	{% endif %}
+
+{% endif %}


### PR DESCRIPTION
Add support for [Hypercomments](https://www.hypercomments.com/) system instead of [Disqus](https://disqus.com/).

### Hypercomments support
- Anonymous comments.
- Inline comments like Duoshuo (u can select any text and make comment for this text).
- Share selected text with title in social (Facebook, Twitter, VK).
- Copy quotes (when u copy selected text from site it will appear at quotes tab in comments).
- Stereocommets (mode with moderators’ avatars/mode with company logo)
- Categories (will help users to add a comment to the appropriate section e.g.'Сriticism', 'Reference', 'Request' etc.).
- Emoji in comments. :relieved:
- Real-time online post views.
- Real-time moderation.

U can see and test live demo of hypercomments [here](https://almostover.ru/2016-10/add-hypercomments-to-hexo-theme-next/).