### PR TITLE
Fixes and improvements.

### DIFF
--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -11,7 +11,7 @@
   <title>{% block title %}{% endblock %}</title>
 </head>
 
-<body itemscope itemtype="//schema.org/WebPage" lang="{{ page.lang || page.language || config.language }}">
+<body itemscope itemtype="http://schema.org/WebPage" lang="{{ page.lang || page.language || config.language }}">
 
   {% include '_scripts/third-party/analytics.swig' %}
 
@@ -23,7 +23,7 @@
   <div class="{{ container_class }} {% block page_class %}{% endblock %} ">
     <div class="headband"></div>
 
-    <header id="header" class="header" itemscope itemtype="//schema.org/WPHeader">
+    <header id="header" class="header" itemscope itemtype="http://schema.org/WPHeader">
       <div class="header-inner"> {%- include '_partials/header.swig' %} </div>
     </header>
 

--- a/layout/_macro/post-collapse.swig
+++ b/layout/_macro/post-collapse.swig
@@ -1,6 +1,6 @@
 {% macro render(post) %}
 
-  <article class="post post-type-{{ post.type | default('normal') }}" itemscope itemtype="//schema.org/Article">
+  <article class="post post-type-{{ post.type | default('normal') }}" itemscope itemtype="http://schema.org/Article">
     <header class="post-header">
 
       <h1 class="post-title">

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -8,7 +8,7 @@
     {% set post_class = post_class + ' ' + 'post-sticky' %}
   {% endif %}
 
-  <article class="{{ post_class }}" itemscope itemtype="//schema.org/Article">
+  <article class="{{ post_class }}" itemscope itemtype="http://schema.org/Article">
   <link itemprop="mainEntityOfPage" href="{{ config.url }}{{ url_for(post.path) }}">
 
     {% if not headlessPost %}
@@ -65,7 +65,7 @@
               </span>
               <span class="post-meta-item-text">{{ __('post.in') }}</span>
               {% for cat in post.categories %}
-                <span itemprop="about" itemscope itemtype="https://schema.org/Thing">
+                <span itemprop="about" itemscope itemtype="http://schema.org/Thing">
                   <a href="{{ url_for(cat.path) }}" itemprop="url" rel="index">
                     <span itemprop="name">{{ cat.name }}</span>
                   </a>
@@ -149,13 +149,13 @@
 
       {# Gallery support #}
       {% if post.photos and post.photos.length %}
-        <div class="post-gallery" itemscope itemtype="//schema.org/ImageGallery">
+        <div class="post-gallery" itemscope itemtype="http://schema.org/ImageGallery">
           {% set COLUMN_NUMBER = 3 %}
           {% for photo in post.photos %}
             {% if loop.index0 % COLUMN_NUMBER === 0 %}<div class="post-gallery-row">{% endif %}
               <a class="post-gallery-img fancybox"
                  href="{{ url_for(photo) }}" rel="gallery_{{ post._id }}"
-                 itemscope itemtype="//schema.org/ImageObject" itemprop="url">
+                 itemscope itemtype="http://schema.org/ImageObject" itemprop="url">
                 <img src="{{ url_for(photo) }}" itemprop="contentUrl"/>
               </a>
             {% if loop.index0 % COLUMN_NUMBER === 2 %}</div>{% endif %}

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -9,6 +9,7 @@
   {% endif %}
 
   <article class="{{ post_class }}" itemscope itemtype="//schema.org/Article">
+  <link itemprop="mainEntityOfPage" href="{{ config.url }}{{ url_for(post.path) }}">
 
     {% if not headlessPost %}
       <header class="post-header">

--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -24,7 +24,7 @@
       {% endif %}
 
       <section class="site-overview sidebar-panel{% if not display_toc or toc(page.content).length <= 1 %} sidebar-panel-active{% endif %}">
-        <div class="site-author motion-element" itemprop="author" itemscope itemtype="//schema.org/Person">
+        <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
           <img class="site-author-image" itemprop="image"
                src="{{ url_for( theme.avatar | default(theme.images + '/avatar.gif') ) }}"
                alt="{{ theme.author }}" />

--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -12,7 +12,7 @@
 
       {% set display_toc = is_post and theme.toc.enable %}
 
-      {% if display_toc %}
+      {% if display_toc and toc(page.content).length > 1 %}
         <ul class="sidebar-nav motion-element">
           <li class="sidebar-nav-toc sidebar-nav-active" data-target="post-toc-wrap" >
             {{ __('sidebar.toc') }}
@@ -23,7 +23,7 @@
         </ul>
       {% endif %}
 
-      <section class="site-overview sidebar-panel {% if not display_toc %} sidebar-panel-active {% endif %}">
+      <section class="site-overview sidebar-panel{% if not display_toc or toc(page.content).length <= 1 %} sidebar-panel-active{% endif %}">
         <div class="site-author motion-element" itemprop="author" itemscope itemtype="//schema.org/Person">
           <img class="site-author-image" itemprop="image"
                src="{{ url_for( theme.avatar | default(theme.images + '/avatar.gif') ) }}"
@@ -111,7 +111,8 @@
 
       </section>
 
-      {% if display_toc %}
+      {% if display_toc and toc(page.content).length > 1 %}
+      <!--noindex-->
         <section class="post-toc-wrap motion-element sidebar-panel sidebar-panel-active">
           <div class="post-toc">
 
@@ -129,6 +130,7 @@
 
           </div>
         </section>
+      <!--/noindex-->
       {% endif %}
 
     </div>

--- a/scripts/tags/note.js
+++ b/scripts/tags/note.js
@@ -1,0 +1,11 @@
+/* global hexo */
+// Class: default, primary, success, info, warning, danger
+// Usage: {% note class %} Content {% endnote %}
+
+function bscallOut (args, content) {
+  return '<div class="note ' + args.join(' ') + '">' +
+            hexo.render.renderSync({text: content, engine: 'markdown'}) +
+          '</div>';
+}
+
+hexo.extend.tag.register('note', bscallOut, {ends: true});

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -18,7 +18,7 @@ pre, code { font-family: $code-font-family; }
 
 code {
   padding: 2px 4px;
-  word-wrap: break-all;
+  word-wrap: break-word;
   color: $highlight-foreground;
   background: $highlight-background;
   border-radius: $code-border-radius;

--- a/source/css/_common/components/tags/note.styl
+++ b/source/css/_common/components/tags/note.styl
@@ -33,8 +33,7 @@
 .default h3
 .default h4
 .default h5
-.default h6
- {
+.default h6 {
   color: #777;
 }
 .primary {

--- a/source/css/_common/components/tags/note.styl
+++ b/source/css/_common/components/tags/note.styl
@@ -1,0 +1,81 @@
+// bs-callout
+// See: http://cpratt.co/twitter-bootstrap-callout-css-styles/
+// ===============================================
+
+.note {
+  padding: 20px;
+  margin: 20px 0;
+  border: 1px solid #eee;
+  border-left-width: 5px;
+  border-radius: 3px;
+}
+.note h2
+.note h3
+.note h4
+.note h5 {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.note p:last-child {
+  margin-bottom: 0;
+}
+.note code {
+  border-radius: 3px;
+}
+.note+.note {
+  margin-top: -5px;
+}
+.default {
+  border-left-color: #777;
+}
+.default h2
+.default h3
+.default h4
+.default h5 {
+  color: #777;
+}
+.primary {
+  border-left-color: #428bca;
+}
+.primary h2
+.primary h3
+.primary h4
+.primary h5 {
+  color: #428bca;
+}
+.success {
+  border-left-color: #5cb85c;
+}
+.success h2
+.success h3
+.success h4
+.success h5 {
+  color: #5cb85c;
+}
+.danger {
+  border-left-color: #d9534f;
+}
+.danger h2
+.danger h3
+.danger h4
+.danger h5 {
+  color: #d9534f;
+}
+.warning {
+  border-left-color: #f0ad4e;
+}
+.warning h2
+.warning h3
+.warning h4
+.warning h5 {
+  color: #f0ad4e;
+}
+.info {
+  border-left-color: #5bc0de;
+}
+.info h2
+.info h3
+.info h4
+.info h5 {
+  color: #5bc0de;
+}

--- a/source/css/_common/components/tags/note.styl
+++ b/source/css/_common/components/tags/note.styl
@@ -12,7 +12,8 @@
 .note h2
 .note h3
 .note h4
-.note h5 {
+.note h5
+.note h6 {
   margin-top: 0;
   margin-bottom: 5px;
 }
@@ -31,7 +32,9 @@
 .default h2
 .default h3
 .default h4
-.default h5 {
+.default h5
+.default h6
+ {
   color: #777;
 }
 .primary {
@@ -40,7 +43,8 @@
 .primary h2
 .primary h3
 .primary h4
-.primary h5 {
+.primary h5
+.primary h6 {
   color: #428bca;
 }
 .success {
@@ -49,7 +53,8 @@
 .success h2
 .success h3
 .success h4
-.success h5 {
+.success h5
+.success h6 {
   color: #5cb85c;
 }
 .danger {
@@ -58,7 +63,8 @@
 .danger h2
 .danger h3
 .danger h4
-.danger h5 {
+.danger h5
+.danger h6 {
   color: #d9534f;
 }
 .warning {
@@ -67,7 +73,8 @@
 .warning h2
 .warning h3
 .warning h4
-.warning h5 {
+.warning h5
+.warning h6 {
   color: #f0ad4e;
 }
 .info {
@@ -76,6 +83,7 @@
 .info h2
 .info h3
 .info h4
-.info h5 {
+.info h5
+.info h6 {
   color: #5bc0de;
 }

--- a/source/css/_common/components/tags/tags.styl
+++ b/source/css/_common/components/tags/tags.styl
@@ -1,3 +1,4 @@
 @import "full-image";
 @import "blockquote-center";
 @import "group-pictures";
+@import "note";


### PR DESCRIPTION
## CSS: add bs-callout notes style.
![image](https://cloud.githubusercontent.com/assets/16944225/19312711/53fee77e-909c-11e6-8cb4-4dd129ee0f5c.png)

## Usage
{% note class %}
Content (md partial supported)
{% endnote %}

Class: default, primary, success, info, warning, danger

### [Live Demo](https://almostover.ru/2016-01/hexo-theme-next-test/).

P.S. In live demo i change style on my own custom styles.