### PR TITLE
加入 Google Calendar 支持，并完成了一个包含前端逻辑的日程页面

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ menu_icons:
   home: home
   about: user
   categories: th
-  schedule: calendar
+  #schedule: calendar
   tags: tags
   archives: archive
   commonweal: heartbeat

--- a/_config.yml
+++ b/_config.yml
@@ -43,12 +43,12 @@ menu:
 #   Key is the name of menu item and value is the name of FontAwsome icon. Key is case-senstive.
 #   When an question mask icon presenting up means that the item has no mapping icon.
 menu_icons:
-  enable: true
+  enable: false
   #KeyMapsToMenuItemKey: NameOfTheIconFromFontAwesome
   home: home
   about: user
   categories: th
-  #schedule: calendar
+  schedule: calendar
   tags: tags
   archives: archive
   commonweal: heartbeat
@@ -342,15 +342,15 @@ baidu_push: false
 # https://developers.google.com/google-apps/calendar/v3/reference/events/list
 calendar:
   enable: false
-#  calendar_id: <required>
-#  api_key: <required>
-#  orderBy: startTime
-#  offsetMax: 24
-#  offsetMin: 4
-#  timeZone:
-#  showDeleted: false
-#  singleEvents: true
-#  maxResults: 250
+  calendar_id: <required>
+  api_key: <required>
+  orderBy: startTime
+  offsetMax: 24
+  offsetMin: 4
+  timeZone:
+  showDeleted: false
+  singleEvents: true
+  maxResults: 250
 
 
 #! ---------------------------------------------------------------

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ menu:
   #about: /about
   archives: /archives
   tags: /tags
+  schedule: /schedule
   #commonweal: /404.html
 
 
@@ -47,6 +48,7 @@ menu_icons:
   home: home
   about: user
   categories: th
+  schedule: calendar
   tags: tags
   archives: archive
   commonweal: heartbeat
@@ -333,6 +335,22 @@ busuanzi_count:
 # Enable baidu push so that the blog will push the url to baidu automatically which is very helpful for SEO
 baidu_push: false
 
+# Google Calendar
+# Share your recent schedule to others via calendar page
+#
+# API Documentation:
+# https://developers.google.com/google-apps/calendar/v3/reference/events/list
+calendar:
+  enable: false
+#  calendar_id: <required>
+#  api_key: <required>
+#  orderBy: startTime
+#  offsetMax: 24
+#  offsetMin: 4
+#  timeZone:
+#  showDeleted: false
+#  singleEvents: true
+#  maxResults: 250
 
 
 #! ---------------------------------------------------------------

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1,6 +1,7 @@
 title:
   archive: Archive
   category: Category
+  schedule: Schedule
   tag: Tag
 
 author: Author
@@ -9,6 +10,7 @@ menu:
   home: Home
   archives: Archives
   categories: Categories
+  schedule: Schedule
   tags: Tags
   about: About
   search: Search

--- a/languages/zh-Hans.yml
+++ b/languages/zh-Hans.yml
@@ -1,6 +1,7 @@
 title:
   archive: 归档
   category: 分类
+  schedule: 日程
   tag: 标签
 
 author: 博主
@@ -9,6 +10,7 @@ menu:
   home: 首页
   archives: 归档
   categories: 分类
+  schedule: 日程
   tags: 标签
   about: 关于
   search: 搜索

--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -71,6 +71,7 @@
   {% include '_scripts/third-party/mathjax.swig' %}
   {% include '_scripts/third-party/lean-analytics.swig' %}
   {% include '_scripts/baidu-push.swig' %}
+  {% include '_scripts/third-party/schedule.swig' %}
 
 </body>
 </html>

--- a/layout/_scripts/third-party/schedule.swig
+++ b/layout/_scripts/third-party/schedule.swig
@@ -16,7 +16,8 @@ var timeMin = new Date();
 var calId           = _n('{{ theme.calendar.calendar_id  }}')                ;
 var apiKey          = _n('{{ theme.calendar.api_key      }}')                ;
 var orderBy         = _n('{{ theme.calendar.ordarBy      }}')  || 'startTime';
-var offsetMax       = _n( {{ theme.calendar.offsetMax    }} )  || 24         ;
+var showLocation    = _n('{{ theme.calendar.showLocation }}')  || 'false'    ;
+var offsetMax       = _n( {{ theme.calendar.offsetMax    }} )  || 72         ;
 var offsetMin       = _n( {{ theme.calendar.offsetMin    }} )  || 4          ;
 var timeZone        = _n( {{ theme.calendar.timeZone     }} )  || void 0     ;
 var showDeleted     = _n( {{ theme.calendar.showDeleted  }} )  || 'false'    ;
@@ -37,7 +38,6 @@ FIELD_SHOWDELETED   = 'showDeleted';
 FIELD_SINGLEEVENTS  = 'singleEvents';
 FIELD_MAXRESULTS    = 'maxResults';
 
-key                 = 'AIzaSyCjcukcNCAjWnIlI8MNatepeUX0038HRTU';
 timeMaxISO          = timeMax.toISOString();
 timeMinISO          = timeMin.toISOString();
 
@@ -54,104 +54,129 @@ if (timeZone) {
   request_url = request_url + '&' + FIELD_TIMEZONE + '=' + timeZone;
 }
 
-var prevStart; // use this variable to decide where to insert an <hr>
+fetchData();
+var queryLoop = setInterval(fetchData, 60000);
 
-// Send query
-$.ajax({
-  dataType: 'json',
-  url: request_url,
-  success: function(data) {
-    cal_data = data;
-    data['items'].forEach((item) => {
+function fetchData() {
+  $.ajax({
+    dataType: 'json',
+    url: request_url,
+    success: function(data) {
 
-      // parse data
-      var start         = new Date(item.start.dateTime);
-      var end           = new Date(item.end.dateTime);
-      var nowFlag       = false;
-      var classNow      = "";
-      var relativeTime  = "";
+      $eventList = $('#schedule #event-list');
 
-      relativeTime = calcTime(now, start);
+      // clean the event list
+      $eventList.html("");
+      var prevEnd = 0; // used to decide where to insert an <hr>
 
-      if (start < now && now < end) {
-        classNow = "event-now";
-        nowFlag = true;
-        relativeTime = "NOW";
-      }
-      else {
-        if (prevStart < now && start > now) {
-          $('#schedule #event-list').append('<hr>');
-        }
-      }
+      data['items'].forEach((event) => {
 
-      $('#schedule #event-list').append('<li class="event ' + classNow + '">' +
-      '<h2 class="event-summary">' +
+        // parse data
+        var start = new Date(event.start.dateTime);
+        var end   = new Date(event.end.dateTime);
 
-      // summary
-      item['summary']
+        tense = judgeTense(now, start, end); // 0:now 1:future -1:past
 
-      + '<span class="event-start">' +
+        if (tense == 1 && prevEnd < now) $eventList.append('<hr>');
 
-      // relative time or NOW if the event is on going
-      relativeTime
+        eventDOM = buildEventDOM(tense, event);
+        $eventList.append(eventDOM);
 
-      + '</span>' +
-      '</h2>' +
-      {% if theme.calendar.showLocation %}
-      (( item['location'] &&
-        ('<span class="event-location">' +
+        prevEnd = end;
+      });
+    }
+  });
+}
 
-        // location
-        item['location']
+function getRelativeTime(current, previous) {
+  var msPerMinute = 60 * 1000;
+  var msPerHour = msPerMinute * 60;
+  var msPerDay = msPerHour * 24;
+  var msPerMonth = msPerDay * 30;
+  var msPerYear = msPerDay * 365;
 
-        + '</span>')
-      ) || "") +
-      {% endif %}
-      '</li>');
+  var elapsed = current - previous;
+  var tense = elapsed > 0 ? "ago" : "later";
 
-      prevStart = start;
-    });
+  elapsed = Math.abs(elapsed);
+
+  if      ( elapsed < msPerHour  ) {
+    return Math.round(elapsed/msPerMinute) + ' minutes ' + tense;
   }
-});
+  else if ( elapsed < msPerDay   ) {
+    return Math.round(elapsed/msPerHour) + ' hours ' + tense;
+  }
+  else if ( elapsed < msPerMonth ) {
+    return 'about ' + Math.round(elapsed/msPerDay) + ' days ' + tense;
+  }
+  else if ( elapsed < msPerYear  ) {
+    return 'about ' + Math.round(elapsed/msPerMonth) + ' months ' + tense;
+  }
+  else {
+    return 'about' + Math.round(elapsed/msPerYear) + ' years' + tense;
+  }
+}
 
-function calcTime(current, previous) {
+function judgeTense(now, eventStart, eventEnd) {
+  if      (eventEnd   < now)  { return -1; }
+  else if (eventStart > now)  { return  1; }
+  else                        { return  0; }
+}
 
-    var msPerMinute = 60 * 1000;
-    var msPerHour = msPerMinute * 60;
-    var msPerDay = msPerHour * 24;
-    var msPerMonth = msPerDay * 30;
-    var msPerYear = msPerDay * 365;
+function buildEventDOM(tense, event) {
+  var tenseClass = "";
+  var start      = new Date(event.start.dateTime);
+  var end        = new Date(event.end.dateTime);
+  switch(tense) {
+    case 0 : // now
+      tenseClass = "event-now";
+      break;
+    case 1 : // future
+      tenseClass = "event-past";
+      break;
+    case -1: // past
+      tenseClass = "event-future";
+      break;
+    default:
+      throw "Time data error";
+  }
+  durationFormat = {
+    weekday: 'short',
+    hour: '2-digit',
+    minute:'2-digit'
+  };
+  relativeTimeStr = (tense == 0) ? "NOW" : getRelativeTime(now, start);
+  durationStr = start.toLocaleTimeString([], durationFormat) + " - " +
+                end.toLocaleTimeString([], durationFormat);
 
-    var elapsed = current - previous;
+  liOpen                = `<li class="event ${tenseClass}">`;
+  liClose               = `</li>`;
+  h2Open                = `<h2 class="event-summary">`;
+  h2Close               = `</h2>`;
 
-    var tense = elapsed > 0 ? "ago" : "later";
+  locationDOM     = "";
+  if (showLocation && event['location']) {
+    locationDOM   = `<span class="event-location event-details">
+                      ${event['location']}
+                     </span>`;
+  }
+  relativeTimeDOM = `<span class="event-relative-time">
+                      ${relativeTimeStr}
+                     </span>`;
+  durationDOM     = `<span class="event-duration event-details">
+                      ${durationStr}
+                     </span>`;
 
-    elapsed = Math.abs(elapsed);
-
-    if (elapsed < msPerMinute) {
-         return Math.round(elapsed/1000) + ' seconds ' + tense;
-    }
-
-    else if (elapsed < msPerHour) {
-         return Math.round(elapsed/msPerMinute) + ' minutes ' + tense;
-    }
-
-    else if (elapsed < msPerDay ) {
-         return Math.round(elapsed/msPerHour ) + ' hours ' + tense;
-    }
-
-    else if (elapsed < msPerMonth) {
-        return 'approximately ' + Math.round(elapsed/msPerDay) + ' days ' + tense;
-    }
-
-    else if (elapsed < msPerYear) {
-        return 'approximately ' + Math.round(elapsed/msPerMonth) + ' months ' + tense;
-    }
-
-    else {
-        return 'approximately ' + Math.round(elapsed/msPerYear ) + ' years' +
-        tense;
-    }
+  eventContent =
+    liOpen +
+      h2Open +
+        event['summary'] +
+        relativeTimeDOM+
+      h2Close +
+      locationDOM +
+      durationDOM +
+    liClose;
+  return eventContent;
 }
 
 </script>

--- a/layout/_scripts/third-party/schedule.swig
+++ b/layout/_scripts/third-party/schedule.swig
@@ -54,6 +54,8 @@ if (timeZone) {
   request_url = request_url + '&' + FIELD_TIMEZONE + '=' + timeZone;
 }
 
+var prevStart; // use this variable to decide where to insert an <hr>
+
 // Send query
 $.ajax({
   dataType: 'json',
@@ -63,42 +65,56 @@ $.ajax({
     data['items'].forEach((item) => {
 
       // parse data
-      var start     = new Date(item.start.dateTime);
-      var end       = new Date(item.end.dateTime);
-      var classNow  = "";
+      var start         = new Date(item.start.dateTime);
+      var end           = new Date(item.end.dateTime);
+      var nowFlag       = false;
+      var classNow      = "";
+      var relativeTime  = "";
 
-      if (start < now && now < end) { classNow = "now"}
+      relativeTime = calcTime(now, start);
 
-      $('#schedule #event-list').append('<li>' +
-      '<h2 class="event-summary ' + classNow + '">' +
+      if (start < now && now < end) {
+        classNow = "event-now";
+        nowFlag = true;
+        relativeTime = "NOW";
+      }
+      else {
+        if (prevStart < now && start > now) {
+          $('#schedule #event-list').append('<hr>');
+        }
+      }
+
+      $('#schedule #event-list').append('<li class="event ' + classNow + '">' +
+      '<h2 class="event-summary">' +
 
       // summary
       item['summary']
 
-      + '</h2>' +
-      '<span class="event-start">' +
+      + '<span class="event-start">' +
 
-      // start-time
-      timeDifference(now, start)
+      // relative time or NOW if the event is on going
+      relativeTime
 
       + '</span>' +
-      '<br>' +
+      '</h2>' +
       {% if theme.calendar.showLocation %}
-      '<span class="event-location">' +
+      (( item['location'] &&
+        ('<span class="event-location">' +
 
-      // location
-      (item['location'] || "")
+        // location
+        item['location']
 
-      + '</span>' +
+        + '</span>')
+      ) || "") +
       {% endif %}
       '</li>');
 
-
+      prevStart = start;
     });
   }
 });
 
-function timeDifference(current, previous) {
+function calcTime(current, previous) {
 
     var msPerMinute = 60 * 1000;
     var msPerHour = msPerMinute * 60;

--- a/layout/_scripts/third-party/schedule.swig
+++ b/layout/_scripts/third-party/schedule.swig
@@ -132,10 +132,10 @@ function buildEventDOM(tense, event) {
       tenseClass = "event-now";
       break;
     case 1 : // future
-      tenseClass = "event-past";
+      tenseClass = "event-future";
       break;
     case -1: // past
-      tenseClass = "event-future";
+      tenseClass = "event-past";
       break;
     default:
       throw "Time data error";

--- a/layout/_scripts/third-party/schedule.swig
+++ b/layout/_scripts/third-party/schedule.swig
@@ -1,0 +1,144 @@
+{% if theme.calendar.enable %}
+{% if page.type == 'schedule' %}
+
+<script>
+
+// Initialization
+var _n = function(arg) { if(arg) return arg; else return void 0;}
+
+var cal_data = void 0;
+
+var now = new Date();
+var timeMax = new Date();
+var timeMin = new Date();
+
+// Read config form theme config file
+var calId           = _n('{{ theme.calendar.calendar_id  }}')                ;
+var apiKey          = _n('{{ theme.calendar.api_key      }}')                ;
+var orderBy         = _n('{{ theme.calendar.ordarBy      }}')  || 'startTime';
+var offsetMax       = _n( {{ theme.calendar.offsetMax    }} )  || 24         ;
+var offsetMin       = _n( {{ theme.calendar.offsetMin    }} )  || 4          ;
+var timeZone        = _n( {{ theme.calendar.timeZone     }} )  || void 0     ;
+var showDeleted     = _n( {{ theme.calendar.showDeleted  }} )  || 'false'    ;
+var singleEvents    = _n( {{ theme.calendar.singleEvents }} )  || 'true'     ;
+var maxResults      = _n( {{ theme.calendar.maxResults   }} )  || '250'      ;
+
+timeMax.setHours(now.getHours() + offsetMax);
+timeMin.setHours(now.getHours() - offsetMin);
+
+// Build URL
+BASE_URL            = 'https://www.googleapis.com/calendar/v3/calendars/';
+FIELD_KEY           = 'key';
+FIELD_ORDERBY       = 'orderBy';
+FIELD_TIMEMAX       = 'timeMax';
+FIELD_TIMEMIN       = 'timeMin';
+FIELD_TIMEZONE      = 'timeZone';
+FIELD_SHOWDELETED   = 'showDeleted';
+FIELD_SINGLEEVENTS  = 'singleEvents';
+FIELD_MAXRESULTS    = 'maxResults';
+
+key                 = 'AIzaSyCjcukcNCAjWnIlI8MNatepeUX0038HRTU';
+timeMaxISO          = timeMax.toISOString();
+timeMinISO          = timeMin.toISOString();
+
+request_url = BASE_URL + calId + '/events?'  +
+  FIELD_KEY           + '=' + apiKey        + '&' +
+  FIELD_ORDERBY       + '=' + orderBy       + '&' +
+  FIELD_TIMEMAX       + '=' + timeMaxISO    + '&' +
+  FIELD_TIMEMIN       + '=' + timeMinISO    + '&' +
+  FIELD_SHOWDELETED   + '=' + showDeleted   + '&' +
+  FIELD_SINGLEEVENTS  + '=' + singleEvents  + '&' +
+  FIELD_MAXRESULTS    + '=' + maxResults;
+
+if (timeZone) {
+  request_url = request_url + '&' + FIELD_TIMEZONE + '=' + timeZone;
+}
+
+// Send query
+$.ajax({
+  dataType: 'json',
+  url: request_url,
+  success: function(data) {
+    cal_data = data;
+    data['items'].forEach((item) => {
+
+      // parse data
+      var start     = new Date(item.start.dateTime);
+      var end       = new Date(item.end.dateTime);
+      var classNow  = "";
+
+      if (start < now && now < end) { classNow = "now"}
+
+      $('#schedule #event-list').append('<li>' +
+      '<h2 class="event-summary ' + classNow + '">' +
+
+      // summary
+      item['summary']
+
+      + '</h2>' +
+      '<span class="event-start">' +
+
+      // start-time
+      timeDifference(now, start)
+
+      + '</span>' +
+      '<br>' +
+      {% if theme.calendar.showLocation %}
+      '<span class="event-location">' +
+
+      // location
+      (item['location'] || "")
+
+      + '</span>' +
+      {% endif %}
+      '</li>');
+
+
+    });
+  }
+});
+
+function timeDifference(current, previous) {
+
+    var msPerMinute = 60 * 1000;
+    var msPerHour = msPerMinute * 60;
+    var msPerDay = msPerHour * 24;
+    var msPerMonth = msPerDay * 30;
+    var msPerYear = msPerDay * 365;
+
+    var elapsed = current - previous;
+
+    var tense = elapsed > 0 ? "ago" : "later";
+
+    elapsed = Math.abs(elapsed);
+
+    if (elapsed < msPerMinute) {
+         return Math.round(elapsed/1000) + ' seconds ' + tense;
+    }
+
+    else if (elapsed < msPerHour) {
+         return Math.round(elapsed/msPerMinute) + ' minutes ' + tense;
+    }
+
+    else if (elapsed < msPerDay ) {
+         return Math.round(elapsed/msPerHour ) + ' hours ' + tense;
+    }
+
+    else if (elapsed < msPerMonth) {
+        return 'approximately ' + Math.round(elapsed/msPerDay) + ' days ' + tense;
+    }
+
+    else if (elapsed < msPerYear) {
+        return 'approximately ' + Math.round(elapsed/msPerMonth) + ' months ' + tense;
+    }
+
+    else {
+        return 'approximately ' + Math.round(elapsed/msPerYear ) + ' years' +
+        tense;
+    }
+}
+
+</script>
+
+{% endif %}
+{% endif %}

--- a/layout/schedule.swig
+++ b/layout/schedule.swig
@@ -3,7 +3,7 @@
 
 {% block title %} {{ __('title.schedule') }} | {{ config.title }} {% endblock %}
 
-{% block page_class %}page-post-detail{% endblock %}
+{% block page_calendar %}page-post-detail{% endblock %}
 
 {% block content %}
 

--- a/layout/schedule.swig
+++ b/layout/schedule.swig
@@ -1,0 +1,19 @@
+{% extends '_layout.swig' %}
+{% import '_macro/sidebar.swig' as sidebar_template %}
+
+{% block title %} {{ __('title.schedule') }} | {{ config.title }} {% endblock %}
+
+{% block page_class %}page-post-detail{% endblock %}
+
+{% block content %}
+
+  <section id="schedule">
+    <ul id="event-list">
+    </ul>
+  </section>
+
+{% endblock %}
+
+{% block sidebar %}
+  {{ sidebar_template.render(false) }}
+{% endblock %}

--- a/source/css/_common/components/pages/pages.styl
+++ b/source/css/_common/components/pages/pages.styl
@@ -2,4 +2,5 @@
 
 @import "archive";
 @import "categories";
+@import "schedule";
 @import "post-detail";

--- a/source/css/_common/components/pages/schedule.styl
+++ b/source/css/_common/components/pages/schedule.styl
@@ -1,3 +1,8 @@
+@keyframes dot-flash {
+    from {opacity: 1; transform:scale(1.1);}
+    to {opacity: 0; transform:scale(1);}
+}
+
 #schedule {
   ul#event-list {
     padding-left: 30px
@@ -20,7 +25,8 @@
       padding-left: 10px
       min-height: 40px
       h2.event-summary {
-        margin:0
+        margin: 0
+        padding-bottom: 3px
         &:before {
           display: inline-block
           font-family: FontAwesome
@@ -31,31 +37,59 @@
           color: #bbb
         }
       }
-      span.event-start {
+      span.event-relative-time {
         display: inline-block
         font-size: 12px
         font-weight: 400
         padding-left: 12px
         color: #bbb
       }
-      span.event-location {
+      span.event-details {
+        display: block
+        color: #bbb
+        margin-left: 56px
+        padding-top: 3px
+        padding-bottom: 6px
+        text-indent: -24px
+        line-height: 18px
+        &:before {
+          text-indent: 0
+          display: inline-block
+          width: 14px
+          font-family: FontAwesome
+          text-align: center
+          margin-right: 9px
+          color: #bbb
+        }
+        &.event-location:before {
+          content: '\f041'
+        }
+        &.event-duration:before {
+          content: '\f017'
+        }
+      }
+    }
+    li.event-past {
+      background: #FCFCFC
+      & > * {
+        opacity: .6
+      }
+      h2.event-summary {
         color: #bbb
         &:before {
-          display: inline-block
-          font-family: FontAwesome
-          content: '\f041'
-          margin-right: 9px
-          margin-left: 32px
-          color: #bbb
+          color: #DFDFDF
         }
       }
     }
     li.event-now {
       background: #222
       color: #FFF
+      padding: 15px 0 15px 10px
       h2.event-summary {
         &:before {
+          transform: scale(1.2)
           color: #FFF
+          animation: dot-flash 1s alternate infinite ease-in-out;
         }
       }
       * {

--- a/source/css/_common/components/pages/schedule.styl
+++ b/source/css/_common/components/pages/schedule.styl
@@ -1,0 +1,67 @@
+#schedule {
+  ul#event-list {
+    padding-left: 30px
+    hr {
+      margin: 20px 0 45px 0!important
+      background: #222
+        &:after {
+          display: inline-block
+          content: 'NOW'
+          background: #222
+          color: #FFF
+          font-weight:bold
+          text-align: right
+          padding: 0 5px
+        }
+    }
+    li.event {
+      margin: 20px 0px
+      background: #F9F9F9
+      padding-left: 10px
+      min-height: 40px
+      h2.event-summary {
+        margin:0
+        &:before {
+          display: inline-block
+          font-family: FontAwesome
+          font-size: 8px
+          content: '\f111'
+          vertical-align: middle
+          margin-right: 25px
+          color: #bbb
+        }
+      }
+      span.event-start {
+        display: inline-block
+        font-size: 12px
+        font-weight: 400
+        padding-left: 12px
+        color: #bbb
+      }
+      span.event-location {
+        color: #bbb
+        &:before {
+          display: inline-block
+          font-family: FontAwesome
+          content: '\f041'
+          margin-right: 9px
+          margin-left: 32px
+          color: #bbb
+        }
+      }
+    }
+    li.event-now {
+      background: #222
+      color: #FFF
+      h2.event-summary {
+        &:before {
+          color: #FFF
+        }
+      }
+      * {
+        color: #FFF!important
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
这是一个可以实时显示一定时间范围内的日程的插件（比如4小时前~24小时后）。

我写了 `layout/_scripts/third-party/schedule.swig` 这个文件，可以在前端读取一个**公开**的 Google Calendar，并将一定时间范围内的日程展示在 schedule 页面上。只需要有 Google Calendar 的 api_key 和对应 calendar 的 calendar_id 即可。获取的数据暂时存储在 cal_data 这个变量中，merge 到 master 的时候可以去掉。

我没有做美化完全就是个骨架，我相信你对主题更了解，如果你喜欢，你能帮我完成吗？

相关的 API Doc：https://developers.google.com/google-apps/calendar/v3/reference/events/list
获取 API_KEY：https://console.developers.google.com/
如何设置公开的 Google 日历：https://support.google.com/calendar/answer/37083?hl=en

目前的效果
http://blog.zealoft.com/schedule/
<img width="935" alt="screen shot 2016-10-14 at 00 16 38" src="https://cloud.githubusercontent.com/assets/7279131/19378820/8d901cc6-91a3-11e6-9237-56f63356099f.png">

TODO:
- [ ] i18n
- [ ] 主题适配
