### PR TITLE
Option to suppress 'menu.' being added before to non-default menu item names

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,8 @@ menu:
   tags: /tags
   #commonweal: /404.html
 
+# By default, non default menu names have "menu." prepend to them.
+prepend_menu: true
 
 # Enable/Disable menu icons.
 # Icon Mapping:

--- a/layout/_partials/header.swig
+++ b/layout/_partials/header.swig
@@ -38,7 +38,11 @@
             {% if theme.menu_icons.enable %}
               <i class="menu-item-icon fa fa-fw fa-{{theme.menu_icons[itemName] | default('question-circle') | lower }}"></i> <br />
             {% endif %}
-            {{ __('menu.' + itemName) }}
+            {% if theme.prepend_menu %}
+              {{ __('menu.' + itemName) }}
+            {% else %}
+              {{ __(itemName) }}
+            {% endif %}
           </a>
         </li>
       {% endfor %}
@@ -66,4 +70,3 @@
     </div>
   {% endif %}
 </nav>
-


### PR DESCRIPTION
## Problem:
Suppose you wanted to add a static page to your site called "Projects". If you create the Projects folder in the same way you create the usual folders like archives and then add it to the theme's `_config.yml` like so:
```yml
menu:
  home: /
  archives: /archives
  projects: /projects
```
you might get a menu icon looking like this:
![Menu.Projects](https://cloud.githubusercontent.com/assets/4149872/19462619/d415be40-94b3-11e6-9ba8-08aaa1480168.png)  
What if the user does *not* want 'Menu' added to the front of the menu name?

## Solution :
This pull request adds an option in the `_config.yml` file that looks like this:
```yml
# By default, non default menu names have "menu." prepend to them.
prepend_menu: true
```
When set to false, the menu now looks like this:
![Projects](https://cloud.githubusercontent.com/assets/4149872/19462664/1859af4e-94b4-11e6-9ba8-af41c674f859.png)
