### PR TITLE
更新 _config.yml文件，解决远程访问空白的问题

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -397,7 +397,7 @@ fancybox: true
 # Please use the https protocol of CDN files when you enable https on your site.
 vendors:
   # Internal path prefix. Please do not edit it.
-  _internal: vendors
+  _internal: lib
 
   # Internal version: 2.1.3
   jquery:


### PR DESCRIPTION
根据https://github.com/iissnan/hexo-theme-next/issues/1214 的描述，我发现主题文件中的 source/vendors 文件夹虽然改成了 source/lib 但其实主题配置文件_config.yml里并没有同步改为_internal: lib，所以即便是用最新的next主题，仍然会遇到在本地看没问题，但是hexo d后远程一片空白的情况。

本次更新就是为了解决以上问题。