### PR TITLE
Add Application Insights analytics support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -285,6 +285,9 @@ mathjax:
 # CNZZ count
 #cnzz_siteid:
 
+# Application Insights
+# See https://azure.microsoft.com/en-us/services/application-insights/
+# application_insights:
 
 # Make duoshuo show UA
 # user_id must NOT be null when admin_enable is true!

--- a/layout/_scripts/third-party/analytics.swig
+++ b/layout/_scripts/third-party/analytics.swig
@@ -3,3 +3,4 @@
 {% include 'analytics/baidu-analytics.swig' %}
 {% include 'analytics/tencent-analytics.swig' %}
 {% include 'analytics/cnzz-analytics.swig' %}
+{% include 'analytics/application-insights.swig' %}

--- a/layout/_scripts/third-party/analytics/application-insights.swig
+++ b/layout/_scripts/third-party/analytics/application-insights.swig
@@ -1,0 +1,11 @@
+{% if theme.application_insights %}
+<script type="text/javascript">
+  var appInsights=window.appInsights||function(config){
+    function i(config){t[config]=function(){var i=arguments;t.queue.push(function(){t[config].apply(t,i)})}}var t={config:config},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{t.cookie=u.cookie}catch(p){}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){var s=f&&f(config,i,u,e,o);return s!==!0&&t["_"+r](config,i,u,e,o),s}),t
+    }({
+        instrumentationKey:"{{ theme.application_insights }}"
+    });
+    window.appInsights=appInsights;
+    appInsights.trackPageView();
+</script>
+{% endif %}


### PR DESCRIPTION
Add Application Insights analytics support. Application Insights for web pages allows to get timings of page loads and AJAX calls, counts and details of browser exceptions and AJAX failures, as well as users and session counts. All these can be segmented by page, client OS and browser version, geo location, and other dimensions. You can set alerts on failure counts or slow page loading. And by inserting trace calls in your JavaScript code, you can track how the different features of your web page application are used. More details can be found on [offical page](https://azure.microsoft.com/en-us/documentation/articles/app-insights-javascript/).