### PR TITLE
Update post-meta.styl

### DIFF
--- a/source/css/_common/components/post/post-meta.styl
+++ b/source/css/_common/components/post/post-meta.styl
@@ -23,7 +23,6 @@
 }
 
 .post-meta-item-icon {
-  display: none;
   margin-right: 3px;
   +tablet() {
     display: inline-block;


### PR DESCRIPTION
remove css class `.post-meta-item-icon` code `display: none;` and then will display all icon
<img width="565" alt="qq20161123-0 2x" src="https://cloud.githubusercontent.com/assets/1863204/20550447/9e680ddc-b170-11e6-8fe9-8c37de4b963d.png">
