### PR TITLE
third-party/uyan: disable uyan.js if uyan is off

### DIFF
--- a/layout/_scripts/third-party/comments/youyan.swig
+++ b/layout/_scripts/third-party/comments/youyan.swig
@@ -5,13 +5,13 @@
   and not theme.gentie_productKey %}
 
   {% if theme.youyan_uid %}
-      {% set uid = theme.youyan_uid %}
-  {% endif %}
+    {% set uid = theme.youyan_uid %}
 
-  {% if page.comments %}
+    {% if page.comments %}
       <!-- UY BEGIN -->
       <script type="text/javascript" src="http://v2.uyan.cc/code/uyan.js?uid={{uid}}"></script>
       <!-- UY END -->
+    {% endif %}
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
The current NexT theme loads a script unconditionally:

        http://v2.uyan.cc/code/uyan.js?uid=

The reason is forgetting to check the value of theme.youyan_uid.

Fix the problem by putting statements in the condition for theme.youyan_uid.
