### PR TITLE
add Tencent MTA support (腾讯移动分析)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -369,6 +369,9 @@ busuanzi_count:
 # Tencent analytics ID
 # tencent_analytics:
 
+# Tencent MTA ID
+# tencent_mta: 
+
 
 # Enable baidu push so that the blog will push the url to baidu automatically which is very helpful for SEO
 baidu_push: false

--- a/layout/_scripts/third-party/analytics.swig
+++ b/layout/_scripts/third-party/analytics.swig
@@ -2,5 +2,6 @@
 {% include 'analytics/google-analytics.swig' %}
 {% include 'analytics/baidu-analytics.swig' %}
 {% include 'analytics/tencent-analytics.swig' %}
+{% include 'analytics/tencent-mta.swig' %}
 {% include 'analytics/cnzz-analytics.swig' %}
 {% include 'analytics/application-insights.swig' %}

--- a/layout/_scripts/third-party/analytics/tencent-mta.swig
+++ b/layout/_scripts/third-party/analytics/tencent-mta.swig
@@ -1,0 +1,14 @@
+{% if theme.tencent_mta %}
+<script>
+  	var _mtac = {};
+  	(function() {
+  		var mta = document.createElement("script");
+  		mta.src = "http://pingjs.qq.com/h5/stats.js?v2.0.2";
+  		mta.setAttribute("name", "MTAH5");
+  		mta.setAttribute("sid", "{{theme.tencent_mta}}");
+
+  		var s = document.getElementsByTagName("script")[0];
+  		s.parentNode.insertBefore(mta, s);
+  	})();
+</script>
+{% endif %}


### PR DESCRIPTION
腾讯分析ta.qq.com已经基本没有在维护了。
现在都是在用http://mta.qq.com，不仅支持应用程序、HTML5还支持小程序

写了篇blog记录了下整个过程
http://blog.aleonchen.com/2017/02/03/MTA/