### PR TITLE
fixed: fancybox not work when can not figure out content type by href

### DIFF
--- a/source/js/src/utils.js
+++ b/source/js/src/utils.js
@@ -15,7 +15,7 @@ NexT.utils = NexT.$u = {
         $imageWrapLink = $image.wrap('<a href="' + this.getAttribute('src') + '"></a>').parent('a');
       }
 
-      $imageWrapLink.addClass('fancybox');
+      $imageWrapLink.addClass('fancybox fancybox.image');
       $imageWrapLink.attr('rel', 'group');
 
       if (imageTitle) {


### PR DESCRIPTION
For example: if href is "https://example.com/test.png!/format/webp", the fancybox will not work well.
Fixed by specify type directly by adding classname "fancybox.image".