### PR TITLE
feat: add the configure for declare copyright on posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,12 @@ authoricon: heart
 # Footer `powered-by` and `theme-info` copyright
 copyright: true
 
+postcopyright:
+  enable: true
+  license: CC BY-NC-SA 3.0 CN
+  license_url: http://creativecommons.org/licenses/by-nc-sa/3.0/cn/
+
+
 # Canonical, set a canonical link tag in your hexo, you could use it for your SEO of blog.
 # See: https://support.google.com/webmasters/answer/139066
 # Tips: Before you open this tag, remember set up your URL in hexo _config.yml ( ex. url: http://yourdomain.com )

--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,9 @@ authoricon: heart
 # Footer `powered-by` and `theme-info` copyright
 copyright: true
 
-postcopyright:
-  enable: true
+# Declare license on posts
+post_copyright:
+  enable: false
   license: CC BY-NC-SA 3.0 CN
   license_url: http://creativecommons.org/licenses/by-nc-sa/3.0/cn/
 

--- a/layout/_macro/post-copyright.swig
+++ b/layout/_macro/post-copyright.swig
@@ -1,0 +1,7 @@
+{% if theme.postcopyright.enable %}
+  <div style="background-color: #f9f9f9; margin-top: 2em; border-left:3px solid #ff1700; padding:.5em 1em;">
+    <strong>本文链接:</strong> <a href="{{ config.url }}{{ url_for(path) }}" title="{{ title }}">{{ config.url }}{{ url_for(path) }}</a>
+    <br>
+    <strong>版权声明:</strong>本博客所有文章除特别声明外，均采用<a href="{{ theme.postcopyright.license_url }}" rel="external nofollow" target="_blank">{{ theme.postcopyright.license }}</a>许可协议。转载请注明出处！<br>
+  </div>
+{% endif %}

--- a/layout/_macro/post-copyright.swig
+++ b/layout/_macro/post-copyright.swig
@@ -1,7 +1,7 @@
-{% if theme.postcopyright.enable %}
+{% if theme.post_copyright.enable %}
   <div style="background-color: #f9f9f9; margin-top: 2em; border-left:3px solid #ff1700; padding:.5em 1em;">
     <strong>本文链接:</strong> <a href="{{ config.url }}{{ url_for(path) }}" title="{{ title }}">{{ config.url }}{{ url_for(path) }}</a>
     <br>
-    <strong>版权声明:</strong>本博客所有文章除特别声明外，均采用<a href="{{ theme.postcopyright.license_url }}" rel="external nofollow" target="_blank">{{ theme.postcopyright.license }}</a>许可协议。转载请注明出处！<br>
+    <strong>版权声明:</strong>本博客所有文章除特别声明外，均采用<a href="{{ theme.post_copyright.license_url }}" rel="external nofollow" target="_blank">{{ theme.post_copyright.license }}</a>许可协议。转载请注明出处！<br>
   </div>
 {% endif %}

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -308,6 +308,11 @@
       {% endif %}
     </div>
 
+    <div>
+      {% if not is_index %}
+        {% include 'post-copyright.swig' %}
+      {% endif %}
+    </div>
 
     <footer class="post-footer">
       {% if post.tags and post.tags.length and not is_index %}


### PR DESCRIPTION

## Config on the `_config.yml`

```yml
# Declare license on posts
post_copyright:
  enable: true
  license: CC BY-NC-SA 3.0 CN
  license_url: http://creativecommons.org/licenses/by-nc-sa/3.0/cn/
```

## Result

![image](https://cloud.githubusercontent.com/assets/6176417/23825283/cacf43ee-06c1-11e7-8ed4-a3cf19941e5c.png)