### PR TITLE
Adjust code block display in mobile for better UX

### DIFF
--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -81,6 +81,7 @@ pre {
   }
 
   .code pre {
+    width: 100%
     padding-left: 10px
     padding-right: 10px
     background-color: $highlight-background

--- a/source/css/_common/components/post/post-expand.styl
+++ b/source/css/_common/components/post/post-expand.styl
@@ -10,8 +10,17 @@
   }
 
   .post-body {
-    pre, .highlight {
+    pre {
       padding: 10px;
+      .gutter pre {
+        padding-right: 10px;
+      }
+    }
+
+    .highlight {
+      margin-left: -40px;
+      margin-right: -40px;
+      padding: 0;
       .gutter pre {
         padding-right: 10px;
       }


### PR DESCRIPTION
When view `Code block` in mobile device frequently need to drag horizontal bar, consider it is not long enough, so make code block full-width in mobile.

