### PR TITLE
fix: codeblock overflows screen when width <= 767px

### DIFF
--- a/source/css/_common/components/post/post-expand.styl
+++ b/source/css/_common/components/post/post-expand.styl
@@ -18,8 +18,8 @@
     }
 
     .highlight {
-      margin-left: -40px;
-      margin-right: -40px;
+      margin-left: 0px;
+      margin-right: 0px;
       padding: 0;
       .gutter pre {
         padding-right: 10px;
@@ -51,7 +51,7 @@
       visibility: visible;
     }
   }
-  
+
   ul li { list-style: circle; }
 
   img {


### PR DESCRIPTION
Code block behaves normal on desktop, here is a demo:

![codeblock-overflow-demo_desktop](https://cloud.githubusercontent.com/assets/7040313/25071108/daaab208-22e1-11e7-919a-f469b82e825f.png)

But when width <= 767px (e.g. on a mobile device), it will overflow screen like this (simulate in Chrome using iPhone 6 device model):

![codeblock-overflow-demo_unfixed](https://cloud.githubusercontent.com/assets/7040313/25071138/776edb1e-22e2-11e7-9351-4d7f41483c97.png)

You can find line numbers overflow screen.
 
After fixed, it behaves normal again (simulate in Chrome using iPhone 6 device model):

![codeblock-overflow-demo_fixed](https://cloud.githubusercontent.com/assets/7040313/25071159/c547e736-22e2-11e7-900d-8950324ff18e.png)
