### PR TITLE
fix: LiveRe's loading conditions fail due to breaking changes of Disqus settings

### DIFF
--- a/layout/_third-party/comments/livere.swig
+++ b/layout/_third-party/comments/livere.swig
@@ -1,6 +1,6 @@
-{% if not (theme.duoshuo and theme.duoshuo.shortname) and not theme.duoshuo_shortname and not theme.disqus_shortname and not theme.hypercomments_id and not theme.gentie_productKey %}
+{% if not (theme.duoshuo and theme.duoshuo.shortname) and not theme.duoshuo_shortname and not (theme.disqus.enable and theme.disqus.shortname) and not theme.hypercomments_id and not theme.gentie_productKey %}
 
-  {% if theme.livere_uid %}
+  {% if page.comments and theme.livere_uid %}
     <script type="text/javascript">
       (function(d, s) {
         var j, e = d.getElementsByTagName(s)[0];


### PR DESCRIPTION
Since Disqus's settings change from `disqus_shortname` to `disqus.enable` and `disqus.shortname`, LiveRe's origin loading conditions fail.

LiveRe will be loaded without checking `page.comments`, I fix it too.
