### PR TITLE
enhancement: add several improvements to local search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -468,8 +468,8 @@ algolia_search:
 # Local search
 local_search:
   enable: false
-  # show top n results per title, show all results by setting to -1
-  top_n_per_title: 1
+  # show top n results per article, show all results by setting to -1
+  top_n_per_article: 1
 
 # External URL with BASE64 encrypt & decrypt
 # Usage: {% exturl text url "title" %}

--- a/_config.yml
+++ b/_config.yml
@@ -468,6 +468,8 @@ algolia_search:
 # Local search
 local_search:
   enable: false
+  # show top n results per title, show all results by setting to -1
+  top_n_per_title: 1
 
 # External URL with BASE64 encrypt & decrypt
 # Usage: {% exturl text url "title" %}

--- a/layout/_third-party/search/localsearch.swig
+++ b/layout/_third-party/search/localsearch.swig
@@ -4,7 +4,7 @@
     var isfetched = false;
     // Search DB path;
     var search_path = "{{ config.search.path }}";
-    if (search_path.length == 0) {
+    if (search_path.length === 0) {
       search_path = "search.xml";
     }
     var path = "{{ config.root }}" + search_path;
@@ -48,127 +48,166 @@
           var $input = document.getElementById(search_id);
           var $resultContent = document.getElementById(content_id);
           $input.addEventListener('input', function(){
-            var matchcounts = 0;
-            var str='<ul class=\"search-result-list\">';
             var keywords = this.value.trim().toLowerCase().split(/[\s\-]+/);
-            $resultContent.innerHTML = "";
+            var resultItems = [];
             if (this.value.trim().length > 0) {
               // perform local searching
               datas.forEach(function(data) {
                 var isMatch = false;
-                var content_index = [];
-                var data_title = data.title.trim().toLowerCase();
-                var data_content = data.content.trim().replace(/<[^>]+>/g,"").toLowerCase();
-                var data_url = decodeURIComponent(data.url);
-                var indices_title = [];
-                var indices_content = [];
-                // only match artiles with not empty titles and contents
-                if(data_title != '') {
+                var hitCountInArticle = 0;
+                var title = data.title.trim();
+                var titleInLowerCase = title.toLowerCase();
+                var content = data.content.trim().replace(/<[^>]+>/g,"");
+                var contentInLowerCase = content.toLowerCase();
+                var articleUrl = decodeURIComponent(data.url);
+                var indexOfTitle = [];
+                var indexOfContent = [];
+                // only match articles with not empty titles
+                if(title != '') {
                   keywords.forEach(function(keyword, i) {
-                    function getIndicesWithWord(word, str, caseSensitive) {
+                    function getIndexByWord(word, text, caseSensitive) {
                       var wordLen = word.length;
-                      if (wordLen == 0) {
+                      if (wordLen === 0) {
                         return [];
                       }
-                      var startIndex = 0, index, indices = [];
+                      var startPosition = 0, position = [], index = [];
                       if (!caseSensitive) {
-                        str = str.toLowerCase();
+                        text = text.toLowerCase();
                         word = word.toLowerCase();
                       }
-                      while ((index = str.indexOf(word, startIndex)) > -1) {
-                        indices.push([index, word]);
-                        startIndex = index + wordLen;
+                      while ((position = text.indexOf(word, startPosition)) > -1) {
+                        index.push([position, word]);
+                        startPosition = position + wordLen;
                       }
-                      return indices;
+                      return index;
                     }
 
-                    indices_title = indices_title.concat(getIndicesWithWord(keyword, data_title, false));
-                    indices_content = indices_content.concat(getIndicesWithWord(keyword, data_content, false));
+                    indexOfTitle = indexOfTitle.concat(getIndexByWord(keyword, titleInLowerCase, false));
+                    indexOfContent = indexOfContent.concat(getIndexByWord(keyword, contentInLowerCase, false));
                   });
-                  if( indices_title.length > 0 || indices_content.length > 0 ){
+                  if (indexOfTitle.length > 0 || indexOfContent.length > 0) {
                     isMatch = true;
+                    hitCountInArticle = indexOfTitle.length + indexOfContent.length;
                   }
                 }
+
                 // show search results
+
                 if (isMatch) {
-                  matchcounts += 1;
+                  var resultItem = '';
 
-                  function highlightKeyword(text, start, end, indices) {
-                    var indexWithWord = indices[indices.length - 1];
-                    var index = indexWithWord[0];
-                    var word = indexWithWord[1];
+                  function highlightKeyword(text, start, end, index) {
+                    var positionAndWord = index[index.length - 1];
+                    var position = positionAndWord[0];
+                    var word = positionAndWord[1];
 
-                    var match_text = text.substring(start, end);
-                    var match_result = [];
+                    var matchText = text.substring(start, end);
+                    var matchResult = [];
                     var prevEnd = 0;
-                    while (index + word.length <= end && indices.length != 0) {
-                      // highlight keyword
-                      var wordBegin = index - start;
-                      var wordEnd = index - start + word.length;
-                      match_result.push(match_text.substring(prevEnd, wordBegin));
-                      match_result.push("<b class=\"search-keyword\">" + match_text.substring(wordBegin, wordEnd) + "</b>");
+                    while (position + word.length <= end && index.length != 0) {
 
-                      // move to next keyword
-                      indices.pop();
+                      // highlight keyword
+
+                      var wordBegin = position - start;
+                      var wordEnd = position - start + word.length;
+                      matchResult.push(matchText.substring(prevEnd, wordBegin));
+                      matchResult.push("<b class=\"search-keyword\">" + matchText.substring(wordBegin, wordEnd) + "</b>");
+
+                      // move to next position of hit
+
+                      index.pop();
                       prevEnd = wordEnd;
-                      while (indices.length != 0) {
-                        indexWithWord = indices[indices.length - 1];
-                        index = indexWithWord[0];
-                        word = indexWithWord[1];
-                        if (prevEnd > index - start) {
-                          indices.pop();
+                      while (index.length != 0) {
+                        positionAndWord = index[index.length - 1];
+                        position = positionAndWord[0];
+                        word = positionAndWord[1];
+                        if (prevEnd > position - start) {
+                          index.pop();
                         } else {
                           break;
                         }
                       }
                     }
-                    match_result.push(match_text.substring(prevEnd));
-                    return match_result.join('');
+                    matchResult.push(matchText.substring(prevEnd));
+                    return matchResult.join('');
                   }
 
-                  if (indices_title.length != 0) {
-                    str += "<li><a href='" + data_url + "' class='search-result-title'>" + highlightKeyword(data_title, 0, data_title.length, indices_title) + "</a>";
-                  } else {
-                    str += "<li><a href='" + data_url + "' class='search-result-title'>" + data_title + "</a>";
-                  }
-                  var content = data.content.trim().replace(/<[^>]+>/g,"");
-                  indices_content.sort(function (a, b) {
-                    return b[0] - a[0];
+                  // sort index by position of keyword
+
+                  indexOfTitle.sort(function (positionAndWordLeft, positionAndWordRight) {
+                    return positionAndWordRight[0] - positionAndWordLeft[0];
                   });
-                  var resultUpperBound = parseInt({{ theme.local_search.top_n_per_title }});
+
+                  indexOfContent.sort(function (positionAndWordLeft, positionAndWordRight) {
+                    return positionAndWordRight[0] - positionAndWordLeft[0];
+                  });
+
+                  // highlight title
+
+                  if (indexOfTitle.length != 0) {
+                    resultItem += "<li><a href='" + articleUrl + "' class='search-result-title'>" + highlightKeyword(title, 0, title.length, indexOfTitle) + "</a>";
+                  } else {
+                    resultItem += "<li><a href='" + articleUrl + "' class='search-result-title'>" + title + "</a>";
+                  }
+
+                  // highlight content
+
+                  var resultUpperBound = parseInt({{ theme.local_search.top_n_per_article }});
                   var withoutUpperBound = false;
-                  if (resultUpperBound == -1) {
+                  if (resultUpperBound === -1) {
                     withoutUpperBound = true;
                   }
                   var currentResultNum = 0;
-                  while (indices_content.length != 0 && (withoutUpperBound || (currentResultNum < resultUpperBound))) {
-                    var indexWithWord = indices_content[indices_content.length - 1];
-                    var index = indexWithWord[0];
-                    var word = indexWithWord[1];
+                  while (indexOfContent.length != 0 && (withoutUpperBound || (currentResultNum < resultUpperBound))) {
+                    var positionAndWord = indexOfContent[indexOfContent.length - 1];
+                    var position = positionAndWord[0];
+                    var word = positionAndWord[1];
                     // cut out 100 characters
-                    var start = index - 20;
-                    var end = index + 80;
+                    var start = position - 20;
+                    var end = position + 80;
                     if(start < 0){
                       start = 0;
                     }
-                    if (end < index + word.length) {
-                      end = index + word.length;
+                    if (end < position + word.length) {
+                      end = position + word.length;
                     }
                     if(end > content.length){
                       end = content.length;
                     }
-                    str += "<a href='" + data_url + "'>" +
-                    "<p class=\"search-result\">" + highlightKeyword(content, start, end, indices_content) +
+                    resultItem += "<a href='" + articleUrl + "'>" +
+                    "<p class=\"search-result\">" + highlightKeyword(content, start, end, indexOfContent) +
                     "...</p>" + "</a>";
                     currentResultNum++;
                   }
-                  str += "</li>";
+                  resultItem += "</li>";
+                  resultItems.push([resultItem, hitCountInArticle, resultItems.length]);
                 }
-              })};
-            str += "</ul>";
-            if (matchcounts == 0) { str = '<div id="no-result"><i class="fa fa-frown-o fa-5x" /></div>' }
-            if (keywords == "") { str = '<div id="no-result"><i class="fa fa-search fa-5x" /></div>' }
-            $resultContent.innerHTML = str;
+              })
+            };
+            if (keywords.length === 1 && keywords[0] === "") {
+              $resultContent.innerHTML = '<div id="no-result"><i class="fa fa-search fa-5x" /></div>'
+            } else if (resultItems.length === 0) {
+              $resultContent.innerHTML = '<div id="no-result"><i class="fa fa-frown-o fa-5x" /></div>'
+            } else {
+              resultItems.sort(function (resultLeft, resultRight) {
+                var hitCountLeft = resultLeft[1];
+                var hitCountRight = resultRight[1];
+                if (hitCountLeft != hitCountRight) {
+                  return hitCountRight - hitCountLeft;
+                } else {
+                  var resultIdLeft = resultLeft[2];
+                  var resultIdRight = resultRight[2];
+                  return resultIdLeft - resultIdRight;
+                }
+              });
+              var searchResultList = '<ul class=\"search-result-list\">';
+              resultItems.forEach(function (result, i) {
+                var item = result[0];
+                searchResultList += item;
+              })
+              searchResultList += "</ul>";
+              $resultContent.innerHTML = searchResultList;
+            }
           });
           proceedsearch();
         }
@@ -177,7 +216,7 @@
     // handle and trigger popup window;
     $('.popup-trigger').click(function(e) {
       e.stopPropagation();
-      if (isfetched == false) {
+      if (isfetched === false) {
         searchFunc(path, 'local-search-input', 'local-search-result');
       } else {
         proceedsearch();

--- a/layout/_third-party/search/localsearch.swig
+++ b/layout/_third-party/search/localsearch.swig
@@ -10,12 +10,23 @@
     var path = "{{ config.root }}" + search_path;
     // monitor main search box;
 
+    var onPopupClose = function (e) {
+      $('.popup').hide();
+      $('#local-search-input').val('');
+      $('.search-result-list').remove();
+      $(".local-search-pop-overlay").remove();
+      $('body').css('overflow', '');
+    }
+
     function proceedsearch() {
       $("body")
         .append('<div class="search-popup-overlay local-search-pop-overlay"></div>')
         .css('overflow', 'hidden');
+      $('.search-popup-overlay').click(onPopupClose);
       $('.popup').toggle();
+      $('#local-search-input').focus();
     }
+
     // search function;
     var searchFunc = function(path, search_id, content_id) {
       'use strict';
@@ -41,7 +52,7 @@
             var str='<ul class=\"search-result-list\">';
             var keywords = this.value.trim().toLowerCase().split(/[\s\-]+/);
             $resultContent.innerHTML = "";
-            if (this.value.trim().length > 1) {
+            if (this.value.trim().length > 0) {
               // perform local searching
               datas.forEach(function(data) {
                 var isMatch = false;
@@ -49,49 +60,100 @@
                 var data_title = data.title.trim().toLowerCase();
                 var data_content = data.content.trim().replace(/<[^>]+>/g,"").toLowerCase();
                 var data_url = decodeURIComponent(data.url);
-                var index_title = -1;
-                var index_content = -1;
-                var first_occur = -1;
+                var indices_title = [];
+                var indices_content = [];
                 // only match artiles with not empty titles and contents
                 if(data_title != '') {
                   keywords.forEach(function(keyword, i) {
-                    index_title = data_title.indexOf(keyword);
-                    index_content = data_content.indexOf(keyword);
-                    if( index_title >= 0 || index_content >= 0 ){
-                      isMatch = true;
-                      if (i == 0) {
-                        first_occur = index_content;
+                    function getIndicesWithWord(word, str, caseSensitive) {
+                      var wordLen = word.length;
+                      if (wordLen == 0) {
+                        return [];
                       }
+                      var startIndex = 0, index, indices = [];
+                      if (!caseSensitive) {
+                        str = str.toLowerCase();
+                        word = word.toLowerCase();
+                      }
+                      while ((index = str.indexOf(word, startIndex)) > -1) {
+                        indices.push([index, word]);
+                        startIndex = index + wordLen;
+                      }
+                      return indices;
                     }
 
+                    indices_title = indices_title.concat(getIndicesWithWord(keyword, data_title, false));
+                    indices_content = indices_content.concat(getIndicesWithWord(keyword, data_content, false));
                   });
+                  if( indices_title.length > 0 || indices_content.length > 0 ){
+                    isMatch = true;
+                  }
                 }
                 // show search results
                 if (isMatch) {
                   matchcounts += 1;
-                  str += "<li><a href='"+ data_url +"' class='search-result-title'>"+ data_title +"</a>";
+
+                  function highlightKeyword(text, start, end, indices) {
+                    var indexWithWord = indices[indices.length - 1];
+                    var index = indexWithWord[0];
+                    var word = indexWithWord[1];
+
+                    var match_text = text.substring(start, end);
+                    var match_result = [];
+                    var prevEnd = 0;
+                    while (index + word.length <= end && indices.length != 0) {
+                      // highlight keyword
+                      var wordBegin = index - start;
+                      var wordEnd = index - start + word.length;
+                      match_result.push(match_text.substring(prevEnd, wordBegin));
+                      match_result.push("<b class=\"search-keyword\">" + match_text.substring(wordBegin, wordEnd) + "</b>");
+
+                      // move to next keyword
+                      indices.pop();
+                      prevEnd = wordEnd;
+                      while (indices.length != 0) {
+                        indexWithWord = indices[indices.length - 1];
+                        index = indexWithWord[0];
+                        word = indexWithWord[1];
+                        if (prevEnd > index - start) {
+                          indices.pop();
+                        } else {
+                          break;
+                        }
+                      }
+                    }
+                    match_result.push(match_text.substring(prevEnd));
+                    return match_result.join('');
+                  }
+
+                  if (indices_title.length != 0) {
+                    str += "<li><a href='" + data_url + "' class='search-result-title'>" + highlightKeyword(data_title, 0, data_title.length, indices_title) + "</a>";
+                  } else {
+                    str += "<li><a href='" + data_url + "' class='search-result-title'>" + data_title + "</a>";
+                  }
                   var content = data.content.trim().replace(/<[^>]+>/g,"");
-                  if (first_occur >= 0) {
+                  indices_content.sort(function (a, b) {
+                    return b[0] - a[0];
+                  });
+                  while (indices_content.length != 0) {
+                    var indexWithWord = indices_content[indices_content.length - 1];
+                    var index = indexWithWord[0];
+                    var word = indexWithWord[1];
                     // cut out 100 characters
-                    var start = first_occur - 20;
-                    var end = first_occur + 80;
+                    var start = index - 20;
+                    var end = index + 80;
                     if(start < 0){
                       start = 0;
                     }
-                    if(start == 0){
-                      end = 50;
+                    if (end < index + word.length) {
+                      end = index + word.length;
                     }
                     if(end > content.length){
                       end = content.length;
                     }
-                    var match_content = content.substring(start, end);
-                    // highlight all keywords
-                    keywords.forEach(function(keyword){
-                      var regS = new RegExp(keyword, "gi");
-                      match_content = match_content.replace(regS, "<b class=\"search-keyword\">"+keyword+"</b>");
-                    });
-
-                    str += "<p class=\"search-result\">" + match_content +"...</p>"
+                    str += "<a href='" + data_url + "'>" +
+                    "<p class=\"search-result\">" + highlightKeyword(content, start, end, indices_content) +
+                    "...</p>" + "</a>";
                   }
                   str += "</li>";
                 }
@@ -115,11 +177,7 @@
       };
     });
 
-    $('.popup-btn-close').click(function(e){
-      $('.popup').hide();
-      $(".local-search-pop-overlay").remove();
-      $('body').css('overflow', '');
-    });
+    $('.popup-btn-close').click(onPopupClose);
     $('.popup').click(function(e){
       e.stopPropagation();
     });

--- a/layout/_third-party/search/localsearch.swig
+++ b/layout/_third-party/search/localsearch.swig
@@ -135,7 +135,13 @@
                   indices_content.sort(function (a, b) {
                     return b[0] - a[0];
                   });
-                  while (indices_content.length != 0) {
+                  var resultUpperBound = parseInt({{ theme.local_search.top_n_per_title }});
+                  var withoutUpperBound = false;
+                  if (resultUpperBound == -1) {
+                    withoutUpperBound = true;
+                  }
+                  var currentResultNum = 0;
+                  while (indices_content.length != 0 && (withoutUpperBound || (currentResultNum < resultUpperBound))) {
                     var indexWithWord = indices_content[indices_content.length - 1];
                     var index = indexWithWord[0];
                     var word = indexWithWord[1];
@@ -154,6 +160,7 @@
                     str += "<a href='" + data_url + "'>" +
                     "<p class=\"search-result\">" + highlightKeyword(content, start, end, indices_content) +
                     "...</p>" + "</a>";
+                    currentResultNum++;
                   }
                   str += "</li>";
                 }

--- a/layout/_third-party/search/localsearch.swig
+++ b/layout/_third-party/search/localsearch.swig
@@ -76,7 +76,7 @@
                         word = word.toLowerCase();
                       }
                       while ((position = text.indexOf(word, startPosition)) > -1) {
-                        index.push([position, word]);
+                        index.push({position: position, word: word});
                         startPosition = position + wordLen;
                       }
                       return index;
@@ -97,9 +97,9 @@
                   var resultItem = '';
 
                   function highlightKeyword(text, start, end, index) {
-                    var positionAndWord = index[index.length - 1];
-                    var position = positionAndWord[0];
-                    var word = positionAndWord[1];
+                    var item = index[index.length - 1];
+                    var position = item.position;
+                    var word = item.word;
 
                     var matchText = text.substring(start, end);
                     var matchResult = [];
@@ -118,9 +118,9 @@
                       index.pop();
                       prevEnd = wordEnd;
                       while (index.length != 0) {
-                        positionAndWord = index[index.length - 1];
-                        position = positionAndWord[0];
-                        word = positionAndWord[1];
+                        item = index[index.length - 1];
+                        position = item.position;
+                        word = item.word;
                         if (prevEnd > position - start) {
                           index.pop();
                         } else {
@@ -134,12 +134,12 @@
 
                   // sort index by position of keyword
 
-                  indexOfTitle.sort(function (positionAndWordLeft, positionAndWordRight) {
-                    return positionAndWordRight[0] - positionAndWordLeft[0];
+                  indexOfTitle.sort(function (itemLeft, itemRight) {
+                    return itemRight.position - itemLeft.position;
                   });
 
-                  indexOfContent.sort(function (positionAndWordLeft, positionAndWordRight) {
-                    return positionAndWordRight[0] - positionAndWordLeft[0];
+                  indexOfContent.sort(function (itemLeft, itemRight) {
+                    return itemRight.position - itemLeft.position;
                   });
 
                   // highlight title
@@ -159,9 +159,9 @@
                   }
                   var currentResultNum = 0;
                   while (indexOfContent.length != 0 && (withoutUpperBound || (currentResultNum < resultUpperBound))) {
-                    var positionAndWord = indexOfContent[indexOfContent.length - 1];
-                    var position = positionAndWord[0];
-                    var word = positionAndWord[1];
+                    var item = indexOfContent[indexOfContent.length - 1];
+                    var position = item.position;
+                    var word = item.word;
                     // cut out 100 characters
                     var start = position - 20;
                     var end = position + 80;
@@ -180,7 +180,7 @@
                     currentResultNum++;
                   }
                   resultItem += "</li>";
-                  resultItems.push([resultItem, hitCountInArticle, resultItems.length]);
+                  resultItems.push({item: resultItem, hitCount: hitCountInArticle, id: resultItems.length});
                 }
               })
             };
@@ -190,20 +190,15 @@
               $resultContent.innerHTML = '<div id="no-result"><i class="fa fa-frown-o fa-5x" /></div>'
             } else {
               resultItems.sort(function (resultLeft, resultRight) {
-                var hitCountLeft = resultLeft[1];
-                var hitCountRight = resultRight[1];
-                if (hitCountLeft != hitCountRight) {
-                  return hitCountRight - hitCountLeft;
+                if (resultLeft.hitCount != resultRight.hitCount) {
+                  return resultRight.hitCount - resultLeft.hitCount;
                 } else {
-                  var resultIdLeft = resultLeft[2];
-                  var resultIdRight = resultRight[2];
-                  return resultIdLeft - resultIdRight;
+                  return resultLeft.id - resultRight.id;
                 }
               });
               var searchResultList = '<ul class=\"search-result-list\">';
               resultItems.forEach(function (result, i) {
-                var item = result[0];
-                searchResultList += item;
+                searchResultList += result.item;
               })
               searchResultList += "</ul>";
               $resultContent.innerHTML = searchResultList;

--- a/source/css/_common/components/third-party/localsearch.styl
+++ b/source/css/_common/components/third-party/localsearch.styl
@@ -43,7 +43,6 @@
 
   .search-keyword
     border-bottom: 1px dashed #f00
-    font-size: 14px
     font-weight: bold
     color: #f00
 
@@ -62,7 +61,7 @@
 
   .local-search-input-wrapper
     display: inline-block
-    width: calc(100% - 60px)
+    width: calc(100% - 90px)
     height: 36px
     line-height: 36px
     padding: 0 5px
@@ -83,6 +82,8 @@
     color: #999
     height: 36px
     width: 18px
+    padding-left: 10px
+    padding-right: 10px
 
   .search-icon
     float: left
@@ -91,7 +92,6 @@
     border-left: 1px solid #eee
     float: right
     cursor: pointer
-    padding-left: 10px
 
   #no-result
     position: absolute


### PR DESCRIPTION
Improvements:

- Let search input get focus automatically when search panel pops up
- Clean search input and search result when search panel closes
- When search panel pops up, click anywhere outside search panel can close it
- Sort result by hit count in article. Demo:

    before:

    <img width="525" alt="search-result-order-before" src="https://cloud.githubusercontent.com/assets/7040313/25302620/96729fdc-2774-11e7-8beb-d5c4e8520b04.png">

    after:

    <img width="525" alt="search-result-order-after" src="https://cloud.githubusercontent.com/assets/7040313/25302621/9f2cded0-2774-11e7-81d6-93fd5d761a86.png">

- Padding search icon and button. Comparison: 

    before:

    <img width="526" alt="search-panel-before" src="https://cloud.githubusercontent.com/assets/7040313/25289425/1e73a602-26fc-11e7-803c-33aed18e2e5a.png">

    after:

    <img width="526" alt="search-panel-after" src="https://cloud.githubusercontent.com/assets/7040313/25289434/253ee5c8-26fc-11e7-8e98-0252ddbd2cbc.png">

- Support to highlight keywords in title. Demo:

    <img width="525" alt="highlight-keywords-demo" src="https://cloud.githubusercontent.com/assets/7040313/25288980/62e2b35c-26fa-11e7-989e-84623688c095.png">

- [**fix**] Let titles be shown with correct letter case instead of all lower case. Demo:

    before:

    <img width="525" alt="search-lowercase" src="https://cloud.githubusercontent.com/assets/7040313/25302662/bd072702-2775-11e7-94a8-7c68260fced9.png">

    after:

    <img width="526" alt="search-correct-case" src="https://cloud.githubusercontent.com/assets/7040313/25302664/c50c5936-2775-11e7-887a-b76811b57da4.png">

- [**fix**] When you input several keywords, all the keywords' result will be shown. Demo:

    before:

    <img width="525" alt="search-show-one" src="https://cloud.githubusercontent.com/assets/7040313/25302720/204accc8-2777-11e7-91c0-f618fefd8966.png">

    after:

    <img width="525" alt="search-fix-letter-case" src="https://cloud.githubusercontent.com/assets/7040313/25302721/33f4b392-2777-11e7-8c68-7f54677b31e3.png">

- Support to show first n highlighted results per article. Originally, search panel can only show first one result per article. Add a new configuration item `local_search.top_n_per_article` to config it. Default value of `local_search.top_n_per_article` is 1 to keep compatibility. Demo:

    `local_search.top_n_per_article` = 0:

    <img width="526" alt="search-show-0" src="https://cloud.githubusercontent.com/assets/7040313/25289971/8038909e-26fe-11e7-8eeb-1ffcafb375d8.png">

    `local_search.top_n_per_article` = 1 (default):

    <img width="526" alt="search-show-1" src="https://cloud.githubusercontent.com/assets/7040313/25289979/88ba23a4-26fe-11e7-97bb-132763d776d6.png">

    `local_search.top_n_per_article` = 3:

    <img width="526" alt="search-show-3" src="https://cloud.githubusercontent.com/assets/7040313/25289999/a02932e6-26fe-11e7-9a48-d6b475a8e18c.png">

    `local_search.top_n_per_article` = -1 (show all results):

    <img width="526" alt="search-show-all" src="https://cloud.githubusercontent.com/assets/7040313/25290001/a70a3f88-26fe-11e7-8871-7f7524de91de.png">


    **Note**: I adjust the result concatenation algorithm to show specified number of results without overlapping highlighted word between adjacent results. It complicates the algorithm. If anyone has simpler solution, tell me ^_^
