### PR TITLE
Upgrade tencent-mta to 2.0.4 and using https

### DIFF
--- a/layout/_third-party/analytics/tencent-mta.swig
+++ b/layout/_third-party/analytics/tencent-mta.swig
@@ -3,7 +3,7 @@
   	var _mtac = {};
   	(function() {
   		var mta = document.createElement("script");
-  		mta.src = "http://pingjs.qq.com/h5/stats.js?v2.0.2";
+  		mta.src = "https://pingjs.qq.com/h5/stats.js?v2.0.4";
   		mta.setAttribute("name", "MTAH5");
   		mta.setAttribute("sid", "{{theme.tencent_mta}}");
 


### PR DESCRIPTION
Http url in https site will cause warning, but https url in http is ok.