### PR TITLE
Add bootstrap label alert

### DIFF
--- a/scripts/tags/alert.js
+++ b/scripts/tags/alert.js
@@ -15,23 +15,23 @@ function alertOut(args, content) {
 
 	switch (style) {
 		case 'success':
-			tip = tip.length == 0 ? tip : "Success Message";
+			tip = tip.length == 0 ? "Success Message" : tip;
 			icon = 'fa-lightbulb-o';
 			break;
 		case 'info':
-			tip = tip.length == 0 ? tip : "Info Message";
+			tip = tip.length == 0 ? "Info Message" : tip;
 			icon = 'fa-info';
 			break;
 		case 'warning':
-			tip = tip.length == 0 ? tip : "Warning Message";
+			tip = tip.length == 0 ? "Warning Message" : tip;
 			icon = 'fa-bell';
 			break;
 		case 'danger':
-			tip = tip.length == 0 ? tip : "Danger Message";
+			tip = tip.length == 0 ? "Danger Message" : tip;
 			icon = 'fa-bug';
 			break;
 		default:
-			tip = tip.length == 0 ? tip : "Success Message";
+			tip = tip.length == 0 ? "Success Message" : tip;
 			icon = 'fa-lightbulb-o';
 			break;
 	}

--- a/scripts/tags/alert.js
+++ b/scripts/tags/alert.js
@@ -1,0 +1,45 @@
+/* global hexo */
+// Class: success, info, warning, danger
+// If class not used ,class is info
+// Usage: {% alert [tip] [class] %} Content {% endalert %}
+
+function alertOut(args, content) {
+	var style, icon, tip;
+	if (args.length > 0) {
+		tip = args[0] || '';
+		style = args[1] || '';
+	}
+	else {
+		style = 'info';
+	}
+
+	switch (style) {
+		case 'success':
+			tip = tip.length == 0 ? tip : "Success Message";
+			icon = 'fa-lightbulb-o';
+			break;
+		case 'info':
+			tip = tip.length == 0 ? tip : "Info Message";
+			icon = 'fa-info';
+			break;
+		case 'warning':
+			tip = tip.length == 0 ? tip : "Warning Message";
+			icon = 'fa-bell';
+			break;
+		case 'danger':
+			tip = tip.length == 0 ? tip : "Danger Message";
+			icon = 'fa-bug';
+			break;
+		default:
+			tip = tip.length == 0 ? tip : "Success Message";
+			icon = 'fa-lightbulb-o';
+			break;
+	}
+
+	content = hexo.render.renderSync({ text: content, engine: 'markdown' });
+	var text = '<div class="alert alert-' + style + '"><i class="fa ' + icon + ' fa-lg">&nbsp;&nbsp;<strong>' + tip + '</strong></i> ' + content + '</div>';
+
+	return text;
+};
+
+hexo.extend.tag.register('alert', alertOut, { ends: true });

--- a/scripts/tags/label.js
+++ b/scripts/tags/label.js
@@ -1,0 +1,16 @@
+/* global hexo */
+// Class: default, primary, success, info, warning, danger
+// Usage: {% label class %} Content {% endlabel %}
+
+function labelOut(args, content) {
+    //var values = args[0];
+    var style;
+    if (args.length > 0) {
+        style = args[0];
+    } else {
+        style = 'default';
+    }
+    return '&nbsp;<span class="label label-' + style + '">' + content + '</span>&nbsp;';
+};
+
+hexo.extend.tag.register('label', labelOut, { ends: true });

--- a/source/css/_common/components/tags/alert.styl
+++ b/source/css/_common/components/tags/alert.styl
@@ -1,0 +1,64 @@
+.alert {
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.alert h4 {
+  margin-top: 0;
+  color: inherit;
+}
+.alert > a {
+  font-weight: bold;
+}
+.alert > p,
+.alert > ul {
+  margin-bottom: 0;
+}
+.alert > p + p {
+  margin-top: 5px;
+}
+.alert-success {
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+  color: #3c763d;
+}
+.alert-success hr {
+  border-top-color: #c9e2b3;
+}
+.alert-success .alert-link {
+  color: #2b542c;
+}
+.alert-info {
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+  color: #31708f;
+}
+.alert-info hr {
+  border-top-color: #a6e1ec;
+}
+.alert-info .alert-link {
+  color: #245269;
+}
+.alert-warning {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  color: #8a6d3b;
+}
+.alert-warning hr {
+  border-top-color: #f7e1b5;
+}
+.alert-warning .alert-link {
+  color: #66512c;
+}
+.alert-danger {
+  background-color: #f2dede;
+  border-color: #ebccd1;
+  color: #a94442;
+}
+.alert-danger hr {
+  border-top-color: #e4b9c0;
+}
+.alert-danger .alert-link {
+  color: #843534;
+}

--- a/source/css/_common/components/tags/label.styl
+++ b/source/css/_common/components/tags/label.styl
@@ -1,0 +1,32 @@
+.label {
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #ffffff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+
+.label-default {
+  background-color: #777777;
+}
+
+.label-primary {
+  background-color: #337ab7;
+}
+.label-success {
+  background-color: #5cb85c;
+}
+.label-info {
+  background-color: #5bc0de;
+}
+.label-warning {
+  background-color: #f0ad4e;
+}
+.label-danger {
+  background-color: #d9534f;
+}

--- a/source/css/_common/components/tags/tags.styl
+++ b/source/css/_common/components/tags/tags.styl
@@ -3,3 +3,5 @@
 @import "group-pictures";
 @import "note";
 @import "exturl" if hexo-config('exturl');
+@import "label";
+@import "alert"


### PR DESCRIPTION
# Label style
> usage: {% label class %} content {% endlabel %}

class : 
> default, primary, success, info, warning, danger

files:
> next\source\css\_common\components\tags\tags.styl
> next\scripts\tags\label.js

站点配置主要在 {% label primary %} 博客根目录 {% endlabel %}的\`_config.yml\`文件中配置

Result:
![image](https://cloud.githubusercontent.com/assets/6817052/26435398/854d5080-4141-11e7-981b-9ee760759376.png)

# Alert
> usage: {% alert [tips] [class] %} content {% endalert %}
> if tips is null then will replace with default string. e.g. *Warning Message (class = warning)*
> content can use Markdow syntax **but except (\``` message \```)**

class : 
> success, info, warning, danger
> class default is success

files:
> next\source\css\_common\components\tags\alert.styl
> next\scripts\tags\alert.js

{% alert "警告提示" warning %}
    \`这是一个警告提示\`
    \# Hello Bootstarp
{% endalert %}

Result:
![image](https://cloud.githubusercontent.com/assets/6817052/26435581/df4d30f4-4142-11e7-83f8-16a67867a565.png)
