### PR TITLE
fix github redirect for add slash issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,10 +45,10 @@ index_with_subtitle: false
 # When running the site in a subdirectory (e.g. domain.tld/blog), remove the leading slash (/archives -> archives)
 menu:
   home: /
-  #categories: /categories
-  #about: /about
-  archives: /archives
-  tags: /tags
+  #categories: /categories/
+  #about: /about/
+  archives: /archives/
+  tags: /tags/
   #sitemap: /sitemap.xml
   #commonweal: /404.html
 


### PR DESCRIPTION
## Issue : 
Menu links does not endwith slash, which cause github do 301 redirection. If use custom domain with https, it will cause twice 301 redirect, first redirected by github to http with slash, then redirect to https, which is not good for SEO.
Example : https://www.paddingleft.com/about
![image](https://cloud.githubusercontent.com/assets/6785698/26790962/37ab4ec6-4a48-11e7-96dc-565bb7729620.png)

## Solution :
Add slash in menu config to reduce redirection.
![image](https://cloud.githubusercontent.com/assets/6785698/26791038/74340d38-4a48-11e7-84b9-745ac66a10e8.png)
