### PR TITLE
將analytics放到<head>中使google webmasters可驗證。

### DIFF
--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -9,11 +9,10 @@
 <head>
   {% include '_partials/head.swig' %}
   <title>{% block title %}{% endblock %}</title>
+  {% include '_third-party/analytics/index.swig' %}
 </head>
 
 <body itemscope itemtype="http://schema.org/WebPage" lang="{{ page.lang || page.language || config.language }}">
-
-  {% include '_third-party/analytics/index.swig' %}
 
   {% set container_class = "container " %}
   {% if theme.sidebar.position %}


### PR DESCRIPTION
在使用Google Webmasters對網站做驗證時，
若Google Analytics追蹤碼不在head中會無法驗證，
將其移動到`<head></head>`中。

![](http://i.imgur.com/6xrfoug.png)