### PR TITLE
fix: using bootcss cdn instead of mathjax official one because the official cdn has been closed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -293,8 +293,7 @@ highlight_theme: normal
 mathjax:
   enable: false
   per_page: false
-  cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
-
+  cdn: //cdn.bootcss.com/mathjax/2.7.1/latest.js?config=TeX-AMS-MML_HTMLorMML
 
 # Han Support docs: https://hanzi.pro/
 han: false


### PR DESCRIPTION
发现mathjax cdn访问很慢，查询后发现，根据官方公布，今年4月份`cdn.mathjax.org`已经关闭了: https://www.mathjax.org/cdn-shutting-down/

---

于是改用国内环境访问较快的: cdn.bootcss.com