### PR TITLE
bug fix: Load the page for the first time, show ribbon

### DIFF
--- a/source/lib/canvas-ribbon/canvas-ribbon.js
+++ b/source/lib/canvas-ribbon/canvas-ribbon.js
@@ -54,7 +54,7 @@
     x = f.random,
     targetA = false;
   c.width = d * l, c.height = r * l, a.scale(l, l), a.globalAlpha = .6, document.onclick = e, document.ontouchend = e, setTimeout(function() {
-    e()
-  }, 100)
-
+    targetA = true;
+    e();
+  }, 100);
 }();


### PR DESCRIPTION
Bug fix: call `e()` function without set the `targetA = true`.