### PR TITLE
Refactor `motion` & sidebar affix global fix.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -558,7 +558,21 @@ tabs:
 #! ---------------------------------------------------------------
 
 # Motion
-use_motion: true
+motion:
+  enable: true
+  async: false
+  transition:
+    # Transition variants:
+    # fadeIn | fadeOut | flipXIn | flipXOut | flipYIn | flipYOut | flipBounceXIn | flipBounceXOut | flipBounceYIn | flipBounceYOut
+    # swoopIn | swoopOut | whirlIn | whirlOut | shrinkIn | shrinkOut | expandIn | expandOut
+    # bounceIn | bounceOut | bounceUpIn | bounceUpOut | bounceDownIn | bounceDownOut | bounceLeftIn | bounceLeftOut | bounceRightIn | bounceRightOut
+    # slideUpIn | slideUpOut | slideDownIn | slideDownOut | slideLeftIn | slideLeftOut | slideRightIn | slideRightOut
+    # slideUpBigIn | slideUpBigOut | slideDownBigIn | slideDownBigOut | slideLeftBigIn | slideLeftBigOut | slideRightBigIn | slideRightBigOut
+    # perspectiveUpIn | perspectiveUpOut | perspectiveDownIn | perspectiveDownOut | perspectiveLeftIn | perspectiveLeftOut | perspectiveRightIn | perspectiveRightOut
+    post_block: fadeIn
+    post_header: slideDownIn
+    post_body: slideDownIn
+    coll_header: slideLeftIn
 
 # Fancybox
 fancybox: true

--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 {% set html_class = 'theme-next ' + theme.scheme %}
-{% if theme.use_motion %}
+{% if theme.motion.enable %}
   {% set html_class = html_class + ' use-motion' %}
 {% endif %}
 
@@ -66,9 +66,9 @@
   {% set scheme_script = '_scripts/schemes/' + theme.scheme | lower + '.swig' %}
   {% include scheme_script %}
 
-  {% block script_extra %}
-    {% include '_scripts/pages/post-details.swig' %}
-  {% endblock %}
+  {% include '_scripts/pages/post-details.swig' %}
+
+  {% block script_extra %}{% endblock %}
 
   {% include '_scripts/boostrap.swig' %}
 

--- a/layout/_partials/head.swig
+++ b/layout/_partials/head.swig
@@ -121,7 +121,7 @@
     sidebar: {{ theme.sidebar | json_encode }},
     fancybox: {{ theme.fancybox }},
     tabs: {{ theme.tabs.enable }},
-    motion: {{ theme.use_motion }},
+    motion: {{ theme.motion | json_encode }},
     duoshuo: {
       userId: '{{ theme.duoshuo_info.user_id | default() }}',
       author: '{{ theme.duoshuo_info.admin_nickname | default(__('author'))}}'

--- a/layout/archive.swig
+++ b/layout/archive.swig
@@ -38,7 +38,7 @@
         {% if post.year !== year %}
           {% set year = post.year %}
           <div class="collection-title">
-            <h2 class="archive-year motion-element" id="archive-year-{{ year }}">{{ year }}</h2>
+            <{% if theme.seo %}h2{% else %}h1{% endif %} class="archive-year" id="archive-year-{{ year }}">{{ year }}</{% if theme.seo %}h2{% else %}h1{% endif %}>
           </div>
         {% endif %}
         {# endshow #}
@@ -59,14 +59,4 @@
 
 {% block sidebar %}
   {{ sidebar_template.render(false) }}
-{% endblock %}
-
-
-{% block script_extra %}
-  {% include '_scripts/pages/post-details.swig' %}
-  {% if theme.use_motion %}
-    <script type="text/javascript" id="motion.page.archive">
-      $('.archive-year').velocity('transition.slideLeftIn');
-    </script>
-  {% endif %}
 {% endblock %}

--- a/source/css/_common/components/pages/archive.styl
+++ b/source/css/_common/components/pages/archive.styl
@@ -1,7 +1,3 @@
-.use-motion {
-  .post { opacity: 0; }
-}
-
 .page-archive {
 
   .archive-page-counter {

--- a/source/css/_common/components/post/post.styl
+++ b/source/css/_common/components/post/post.styl
@@ -33,6 +33,13 @@
   transform: rotate(30deg);
 }
 
+.use-motion {
+  if hexo-config('motion.transition.post_block') { .post-block { opacity: 0; } }
+  if hexo-config('motion.transition.post_header') { .post-header { opacity: 0; } }
+  if hexo-config('motion.transition.post_body') { .post-body { opacity: 0; } }
+  if hexo-config('motion.transition.coll_header') { .collection-title { opacity: 0; } }
+}
+
 @import "post-expand";
 @import "post-collapse";
 @import "post-type";

--- a/source/js/src/bootstrap.js
+++ b/source/js/src/bootstrap.js
@@ -46,7 +46,7 @@ $(document).ready(function () {
   $(document).trigger('motion:before');
 
   // Bootstrap Motion.
-  CONFIG.motion && NexT.motion.integrator.bootstrap();
+  CONFIG.motion.enable && NexT.motion.integrator.bootstrap();
 
   $(document).trigger('bootstrap:after');
 });

--- a/source/js/src/motion.js
+++ b/source/js/src/motion.js
@@ -234,6 +234,10 @@ $(document).ready(function () {
         o: {duration: 200}
       });
 
+      if (CONFIG.motion.async) {
+        integrator.next();
+      }
+
       if (sequence.length > 0) {
         sequence[sequence.length - 1].o.complete = function () {
           integrator.next();
@@ -269,6 +273,11 @@ $(document).ready(function () {
     },
 
     menu: function (integrator) {
+
+      if (CONFIG.motion.async) {
+        integrator.next();
+      }
+
       $('.menu-item').velocity('transition.slideDownIn', {
         display: null,
         duration: 200,
@@ -279,10 +288,22 @@ $(document).ready(function () {
     },
 
     postList: function (integrator) {
-      var $post = $('.post');
-      var hasPost = $post.size() > 0;
+      //var $post = $('.post');
+      var $postBlock = $('.post-block');
+      var $postBlockTransition = CONFIG.motion.transition.post_block;
+      var $postHeader = $('.post-header');
+      var $postHeaderTransition = CONFIG.motion.transition.post_header;
+      var $postBody = $('.post-body');
+      var $postBodyTransition = CONFIG.motion.transition.post_body;
+      var $collHeader = $('.collection-title, .archive-year');
+      var $collHeaderTransition = CONFIG.motion.transition.coll_header;
+      var hasPost = $postBlock.size() > 0;
 
       hasPost ? postMotion() : integrator.next();
+
+      if (CONFIG.motion.async) {
+        integrator.next();
+      }
 
       function postMotion () {
         var postMotionOptions = window.postMotionOptions || {
@@ -293,7 +314,19 @@ $(document).ready(function () {
           integrator.next();
         };
 
-        $post.velocity('transition.slideDownIn', postMotionOptions);
+        //$post.velocity('transition.slideDownIn', postMotionOptions);
+        if (CONFIG.motion.transition.post_block) {
+          $postBlock.velocity('transition.' + $postBlockTransition, postMotionOptions);
+        }
+        if (CONFIG.motion.transition.post_header) {
+          $postHeader.velocity('transition.' + $postHeaderTransition, postMotionOptions);
+        }
+        if (CONFIG.motion.transition.post_body) {
+          $postBody.velocity('transition.' + $postBodyTransition, postMotionOptions);
+        }
+        if (CONFIG.motion.transition.coll_header) {
+          $collHeader.velocity('transition.' + $collHeaderTransition, postMotionOptions);
+        }
       }
     },
 


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/iissnan/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number(s): #967.

## What is the new behavior?
1. Sidebar affix don't work globally (block extra was wrong usage).
2. Now `motion` option have more options:
   * **Breaking changes**: rename `use_motion` to `motion` in main NexT config.
   * Option to `async` loading. That's mean effects on logo, menu, post will load in same time if `true`; if `false` — this items will load after each other.
   * Transition variants (see config comments).
   * Motion effects now work for all pages (#967) and tags/category headers too.

In NexT `_config.yml`:
```diff
# Motion
-use_motion: true
+motion:
+  enable: true
+  async: false
+  transition:
+    # Transition variants:
+    # fadeIn | fadeOut | flipXIn | flipXOut | flipYIn | flipYOut | flipBounceXIn | flipBounceXOut | flipBounceYIn | flipBounceYOut
+    # swoopIn | swoopOut | whirlIn | whirlOut | shrinkIn | shrinkOut | expandIn | expandOut
+    # bounceIn | bounceOut | bounceUpIn | bounceUpOut | bounceDownIn | bounceDownOut | bounceLeftIn | bounceLeftOut | bounceRightIn | bounceRightOut
+    # slideUpIn | slideUpOut | slideDownIn | slideDownOut | slideLeftIn | slideLeftOut | slideRightIn | slideRightOut
+    # slideUpBigIn | slideUpBigOut | slideDownBigIn | slideDownBigOut | slideLeftBigIn | slideLeftBigOut | slideRightBigIn | slideRightBigOut
+    # perspectiveUpIn | perspectiveUpOut | perspectiveDownIn | perspectiveDownOut | perspectiveLeftIn | perspectiveLeftOut | perspectiveRightIn | perspectiveRightOut
+    post_block: fadeIn
+    post_header: slideDownIn
+    post_body: slideDownIn
+    coll_header: slideLeftIn
```
**P.S.** U can comment any of 4 elements if u don't want to use effects on they.
E.g. comment `post_block: fadeIn` — will not add motion effects to blocks on all posts.

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!-- 
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```
...
```
-->
