### PR TITLE
tencent weibo typo #1833

### DIFF
--- a/layout/_partials/share/jiathis.swig
+++ b/layout/_partials/share/jiathis.swig
@@ -6,7 +6,7 @@
 <a class="jiathis_button_email">邮件</a>
 <a class="jiathis_button_weixin">微信</a>
 <a class="jiathis_button_qzone">QQ空间</a>
-<a class="jiathis_button_tqq">腾讯微薄</a>
+<a class="jiathis_button_tqq">腾讯微博</a>
 <a class="jiathis_button_douban">豆瓣</a>
 <a class="jiathis_button_share">一键分享</a>
 


### PR DESCRIPTION
`腾讯微薄` should be `腾讯微博`

https://github.com/iissnan/hexo-theme-next/issues/1833