### PR TITLE
Remove line-height declaration

### DIFF
--- a/source/css/_common/components/pagination.styl
+++ b/source/css/_common/components/pagination.styl
@@ -7,9 +7,8 @@
 .page-number-basic {
   display: inline-block;
   position: relative;
-  top: -1px;
   margin: 0 10px;
-  padding: 0 10px;
+  padding: 0 11px;
 
   +mobile() { margin: 0 5px; }
 }
@@ -49,6 +48,7 @@
       margin-bottom: 10px;
       border-top: 0;
       border-bottom: 1px solid $pagination-link-border;
+      padding: 0 10px;
 
       &:hover { border-bottom-color: $pagination-link-hover-border; }
     }

--- a/source/css/_common/components/pagination.styl
+++ b/source/css/_common/components/pagination.styl
@@ -10,7 +10,6 @@
   top: -1px;
   margin: 0 10px;
   padding: 0 10px;
-  line-height: 30px;
 
   +mobile() { margin: 0 5px; }
 }
@@ -44,7 +43,7 @@
 
 @media (max-width: 767px)
   .pagination { border-top: none; }
-  
+
   .pagination {
     .prev, .next, .page-number {
       margin-bottom: 10px;


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/iissnan/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Line height was set with a fixed size. This would break easily if you increase/decrease the base font-size.

![before](https://user-images.githubusercontent.com/1237070/30516219-85e820b4-9b38-11e7-9274-67b93a320185.png)


## What is the new behavior?
Removing the rule, allows the element to inherit the line-height, which is governed by the theme and auto-calculated. Making the overall pagination working just fine.

![after](https://user-images.githubusercontent.com/1237070/30516223-a6eccb5c-9b38-11e7-9b58-9b46e35bc217.png)


### How to use?
Nothing to be done.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!-- 
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```
...
```
-->
