### PR TITLE
Exclude img in link from fancybox

### DIFF
--- a/source/js/src/utils.js
+++ b/source/js/src/utils.js
@@ -8,6 +8,7 @@ NexT.utils = NexT.$u = {
     $('.content img')
       .not('[hidden]')
       .not('.group-picture img, .post-gallery img')
+	  .not('a img')
       .each(function () {
         var $image = $(this);
         var imageTitle = $image.attr('title');


### PR DESCRIPTION
## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Click on a img in link won't open link, but show a fancybox.

## What is the new behavior?
Click on a img in link just open link as usual.

* Screens with this changes: [http://recordit.co/pp1DR0EjJw](http://recordit.co/pp1DR0EjJw)
* Link to demo site with this changes: [https://blog.maple3142.net/404.html](https://blog.maple3142.net/404.html)

### How to use?
Add image in link.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
