### PR TITLE
comments switch use enable better than others

### DIFF
--- a/layout/_partials/comments.swig
+++ b/layout/_partials/comments.swig
@@ -47,7 +47,7 @@
       <div id="lv-container" data-id="city" data-uid="{{ theme.livere_uid }}"></div>
     </div>
 
-  {% elseif theme.changyan.appid and theme.changyan.appkey %}
+  {% elseif theme.changyan.enable %}
     <div class="comments" id="comments">
       <div id="SOHUCS"></div>
     </div>


### PR DESCRIPTION
comments switch use `enable` better than others
### Why?
if sameone fill `changyan.appid` and `changyan.appkey` ,but close `changyan.enable`.It can't run as we expected.



