### PR TITLE
adjust sidebar hide time in Next.Mist

### DIFF
--- a/source/css/_schemes/Mist/outline/outline.styl
+++ b/source/css/_schemes/Mist/outline/outline.styl
@@ -1,1 +1,45 @@
+//margin-left and margin-right  size
+$offset-margin = 30px;
+
 .main-inner { margin-top: 80px; }
+
+// 767px < screen <  $content-desktop + marginLeft + marginRight        (add marginLeft and marginRight)
+@media only screen and (min-width: 767px) and (max-width: $content-desktop + ($offset-margin * 2)){
+  .header-inner,
+  .main-inner,
+  .footer-inner{
+    margin-left: $offset-margin;
+    margin-right: $offset-margin;
+  }
+}
+
+// screen <  $content-desktop + marginLeft + marginRight   +  sidebarWidth    (hide sidebar)
+@media only screen and (max-width: $content-desktop-large + ($offset-margin * 2) + $sidebar-desktop){
+  body {
+    padding-left: 0 !important;
+  }
+  .sidebar {
+    display: none !important;
+  }
+}
+
++desktop-large() {
+// 767px < screen <  $content-desktop-large + marginLeft + marginRight         (add marginLeft and marginRight)
+  @media only screen and (min-width: 767px) and (max-width: $content-desktop-large + ($offset-margin * 2)){
+    .header-inner,
+    .main-inner,
+    .footer-inner{
+      margin-left: $offset-margin;
+      margin-right: $offset-margin;
+    }
+  }
+// screen <  $content-desktop-large + marginLeft + marginRight  +  sidebarWidth      (hide sidebar)
+  @media only screen and (max-width: $content-desktop-large + ($offset-margin * 2) + $sidebar-desktop){
+    body {
+      padding-left: 0 !important;
+    }
+    .sidebar {
+      display: none !important;
+    }
+  }
+}


### PR DESCRIPTION

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [ ] The commit message follows [our guidelines](https://github.com/iissnan/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Mist have been tested.
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.

## What is the new behavior?
Description about this pull, in several words...

* Screens with this changes:  you can resize brower, when brower size between 767px and $content-desktop(or $content-desktop-large) , the layout is terrible and the sidebar not hide.

* Link to demo site with this changes: [zhuzhuyule.com](https://zhuzhuyule.com) 

