### PR TITLE
fix layout beautiful when browser changes size !

### DIFF
--- a/source/css/_common/outline/outline.styl
+++ b/source/css/_common/outline/outline.styl
@@ -18,10 +18,10 @@ html, body { height: 100%; }
 .header-inner {
   margin: 0 auto;
   padding: 100px 0 70px;
-  width: $content-desktop;
+  max-width: $content-desktop;
 
   +desktop-large() {
-    .container & { width: $content-desktop-large; }
+    .container & { max-width: $content-desktop-large; }
   }
 }
 
@@ -30,10 +30,10 @@ html, body { height: 100%; }
 .main { padding-bottom: $footer-height + $gap-between-main-and-footer; }
 .main-inner {
   margin: 0 auto;
-  width: $content-desktop;
+  max-width: $content-desktop;
 
   +desktop-large() {
-    .container & { width: $content-desktop-large; }
+    .container & { max-width: $content-desktop-large; }
   }
 }
 
@@ -50,9 +50,9 @@ html, body { height: 100%; }
 .footer-inner {
   box-sizing: border-box;
   margin: 20px auto;
-  width: $content-desktop;
+  max-width: $content-desktop;
 
   +desktop-large() {
-    .container & { width: $content-desktop-large; }
+    .container & { max-width: $content-desktop-large; }
   }
 }


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [ ] The commit message follows [our guidelines](https://github.com/iissnan/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Mist have been tested.
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [x] Code style update (formatting, local variables).
- [ ] Feature.
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.

## What is the new behavior?
Description about this pull, in several words...

* Screens with this changes:  you can resize brower, when brower size between 767px and $content-desktop(or $content-desktop-large) , the layout is terrible and the sidebar not hide.

* Link to demo site with this changes: [zhuzhuyule.com](https://zhuzhuyule.com) 

