### PR TITLE
fixed a problem of 'reward and wechat-subscriber'

### DIFF
--- a/layout/_macro/reward.swig
+++ b/layout/_macro/reward.swig
@@ -7,21 +7,21 @@
 
     {% if theme.wechatpay %}
       <div id="wechat" style="display: inline-block">
-        <img id="wechat_qr" src="{{ theme.wechatpay }}" alt="{{ theme.author }} {{ __('reward.wechatpay') }}"/>
+        <img id="wechat_qr" src="{{ url_for(theme.wechatpay) }}" alt="{{ theme.author }} {{ __('reward.wechatpay') }}"/>
         <p>{{ __('reward.wechatpay') }}</p>
       </div>
     {% endif %}
 
     {% if theme.alipay %}
       <div id="alipay" style="display: inline-block">
-        <img id="alipay_qr" src="{{ theme.alipay }}" alt="{{ theme.author }} {{ __('reward.alipay') }}"/>
+        <img id="alipay_qr" src="{{ url_for(theme.alipay) }}" alt="{{ theme.author }} {{ __('reward.alipay') }}"/>
         <p>{{ __('reward.alipay') }}</p>
       </div>
     {% endif %}
 
     {% if theme.bitcoin %}
       <div id="bitcoin" style="display: inline-block">
-        <img id="bitcoin_qr" src="{{ theme.bitcoin }}" alt="{{ theme.author }} {{ __('reward.bitcoin') }}"/>
+        <img id="bitcoin_qr" src="{{ url_for(theme.bitcoin) }}" alt="{{ theme.author }} {{ __('reward.bitcoin') }}"/>
         <p>{{ __('reward.bitcoin') }}</p>
       </div>
     {% endif %}

--- a/layout/_macro/wechat-subscriber.swig
+++ b/layout/_macro/wechat-subscriber.swig
@@ -1,4 +1,4 @@
 <div id="wechat_subscriber" style="display: block; padding: 10px 0; margin: 20px auto; width: 100%; text-align: center">
-    <img id="wechat_subscriber_qcode" src="{{ theme.wechat_subscriber.qcode }}" alt="{{ theme.author }} wechat" style="width: 200px; max-width: 100%;"/>
+    <img id="wechat_subscriber_qcode" src="{{ url_for(theme.wechat_subscriber.qcode) }}" alt="{{ theme.author }} wechat" style="width: 200px; max-width: 100%;"/>
     <div>{{ theme.wechat_subscriber.description }}</div>
 </div>


### PR DESCRIPTION
fixed the problem that the images of 'reward and wechat-subscriber area' can't display when the main '_config.yml' set 'root: /xxxxxx/'

<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/iissnan/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the images of 'reward and wechat-subscriber area' can't display when the main '_config.yml' set 'root: /xxxxxx/'
Issue Number(s): N/A

## What is the new behavior?
Now if you set the main '_config.yml' as 'root: /xxxxxx/', the images of 'reward and wechat-subscriber area' can display correctly.

* Screens with this changes: N/A
* Link to demo site with this changes: https://kuleyu.github.io/hexolog/post/20990.html

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!-- 
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
